### PR TITLE
docs: align required checks with stable gates

### DIFF
--- a/docs/security/code-security.md
+++ b/docs/security/code-security.md
@@ -16,4 +16,5 @@ BandScope treats GitHub Code Security as part of bootstrap governance.
 
 - `main` and `develop` must require the stable checks documented in `docs/repository/bootstrap-plan.md`
 - Code Security controls must not be arbitrarily disabled or bypassed
+- External AI-review status contexts may be requested but should not be the sole required status gate when the provider is operationally flaky.
 - missing permissions to enable GitHub-native controls are `BLOCKED`, not justification to weaken the baseline

--- a/docs/security/github-required-checks.md
+++ b/docs/security/github-required-checks.md
@@ -6,7 +6,6 @@ These are the merge-gate status checks that should be required on protected bran
 
 ### `develop`
 
-- `CodeRabbit`
 - `ci / build-and-test`
 - `dependency-review`
 - `security-audit`
@@ -21,7 +20,6 @@ These are the merge-gate status checks that should be required on protected bran
 
 ### `main`
 
-- `CodeRabbit`
 - `ci / build-and-test`
 - `dependency-review`
 - `security-audit`
@@ -40,7 +38,7 @@ These are required repository settings or GitHub security features, not branch s
 - Dependency graph: required
 - Dependency submission coverage: required where GitHub supports it for the repository setup
 - Dependency review gate on PRs: required
-- CodeRabbit review gate substitution: required
+- CodeRabbit review request and review-equivalent policy: required
 
 ## Workflow-managed baseline
 
@@ -66,6 +64,12 @@ These controls are expressed by repo workflows and are expected to be connected 
 
 The files in this repository define the workflows and the intended check names.
 Actual branch protection, required checks, and GitHub security feature activation must be enforced in the GitHub repository settings or rulesets with repository admin permissions.
+
+## CodeRabbit enforcement note
+
+BandScope still requests CodeRabbit on PRs and treats it as the default AI review path.
+However, the hosted `CodeRabbit` status context has shown repeated stale `PENDING` and stale `CHANGES_REQUESTED` states after all actionable review was cleared.
+Because of that operational behavior, protected branches require the stable repository-owned checks above rather than the external `CodeRabbit` status context itself.
 
 Missing repository state should trigger GitHub bootstrap per `docs/workflow/github-bootstrap-execution-policy.md`.
 Only missing admin permissions or platform capability should be reported as `BLOCKED`.

--- a/docs/workflow/github-bootstrap-execution-policy.md
+++ b/docs/workflow/github-bootstrap-execution-policy.md
@@ -43,7 +43,8 @@ Bootstrap or setup work is not complete unless GitHub-facing supply-chain contro
 - `.github/workflows/codeql.yml`
 - `.github/workflows/sbom.yml`
 - `.github/workflows/release.yml`
-- branch protection or rulesets for `main` and `develop` that require `CodeRabbit`, `ci / build-and-test`, `dependency-review`, `security-audit`, `CodeQL`, `sbom`, `release-preflight`, `gate / build / windows`, and `gate / build / macos`
+- branch protection or rulesets for `main` and `develop` that require `ci / build-and-test`, `dependency-review`, `security-audit`, `CodeQL`, `sbom`, `release-preflight`, `gate / build / windows`, and `gate / build / macos`
+- PR workflow that still requests CodeRabbit review and records its result when the provider responds cleanly
 - release retention for the generated SBOM and supplemental inventory
 
 Do not treat these as TODOs, later hardening, or optional recommendations.


### PR DESCRIPTION
## Summary
- update required-check docs to match the stable branch protection gate set after removing the flaky external CodeRabbit status context
- keep CodeRabbit as the requested AI review path while documenting why the hosted status context is no longer a required branch-protection check

## Verification
- `python3 scripts/checks/verify_github_bootstrap_policy.py`
- `python3 scripts/checks/verify_docs.py`