### PR TITLE
fix: constrain analysis interpreter discovery to trusted roots

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -480,6 +480,16 @@ fn run_analysis_engine(
     requested_at: String,
 ) -> AnalysisJobStatus {
     let (working_dir, program, args) = analysis_command();
+
+    if program == "__bandscope_missing_analysis_python__" {
+        return failed_status(
+            job_id,
+            requested_at,
+            AnalysisJobErrorCode::EngineUnavailable,
+            "Analysis engine is unavailable.",
+        );
+    }
+
     let mut process = match Command::new(program)
         .args(args)
         .current_dir(working_dir)

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -210,16 +210,9 @@ fn runtime_search_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
     if let Ok(current_exe) = std::env::current_exe() {
         if let Some(parent) = current_exe.parent() {
-            for ancestor in parent.ancestors() {
-                unique_push(&mut roots, ancestor.to_path_buf());
-            }
+            unique_push(&mut roots, parent.to_path_buf());
             unique_push(&mut roots, parent.join("resources"));
             unique_push(&mut roots, parent.join("../Resources"));
-        }
-    }
-    if let Ok(current_dir) = std::env::current_dir() {
-        for ancestor in current_dir.ancestors() {
-            unique_push(&mut roots, ancestor.to_path_buf());
         }
     }
     roots
@@ -266,7 +259,7 @@ fn analysis_command() -> (PathBuf, String, Vec<String>) {
         ];
 
         for candidate in candidates {
-            if candidate.exists() {
+            if candidate.is_file() {
                 return (
                     root,
                     candidate.to_string_lossy().into_owned(),
@@ -276,19 +269,10 @@ fn analysis_command() -> (PathBuf, String, Vec<String>) {
         }
     }
 
-    let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-
     (
-        working_dir,
-        "uv".into(),
-        vec![
-            "run".into(),
-            "--project".into(),
-            "services/analysis-engine".into(),
-            "python".into(),
-            "-m".into(),
-            "bandscope_analysis.cli".into(),
-        ],
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        "__bandscope_missing_analysis_python__".into(),
+        Vec::new(),
     )
 }
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ const MAX_IN_FLIGHT_JOBS: usize = 2;
 const ANALYSIS_PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 const ANALYSIS_WAIT_POLL: Duration = Duration::from_millis(50);
 const AUDIO_EXTENSIONS: [&str; 4] = ["wav", "mp3", "flac", "m4a"];
+const MISSING_ANALYSIS_PYTHON: &str = "__bandscope_missing_analysis_python__";
 
 impl Default for AppState {
     fn default() -> Self {
@@ -271,7 +272,7 @@ fn analysis_command() -> (PathBuf, String, Vec<String>) {
 
     (
         std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        "__bandscope_missing_analysis_python__".into(),
+        MISSING_ANALYSIS_PYTHON.into(),
         Vec::new(),
     )
 }
@@ -481,7 +482,7 @@ fn run_analysis_engine(
 ) -> AnalysisJobStatus {
     let (working_dir, program, args) = analysis_command();
 
-    if program == "__bandscope_missing_analysis_python__" {
+    if program == MISSING_ANALYSIS_PYTHON {
         return failed_status(
             job_id,
             requested_at,


### PR DESCRIPTION
### Motivation
- The previous interpreter discovery walked ancestors of `current_exe` and `current_dir`, which allowed local binary planting (untrusted, writable directories could supply a malicious `analysis-engine/.venv/bin/python`).
- The launcher also fell back to running `uv` from `PATH`, which is unpinned and increases attack surface.
- This change eliminates discovery across user-controlled ancestor paths and closes the unpinned `uv` fallback to reduce arbitrary code execution risk.

### Description
- Restricted `runtime_search_roots()` to only include the executable parent and packaged resource locations instead of walking `current_dir` ancestors. (`apps/desktop/src-tauri/src/main.rs`)
- Tightened candidate validation from `exists()` to `is_file()` so only regular files are accepted as interpreters. (`analysis_command`) 
- Removed the unpinned `"uv"` PATH fallback; when no trusted interpreter is found the function now returns a sentinel program and empty args so the existing spawn/error handling reports engine-unavailable instead of executing arbitrary PATH binaries.
- Small behavior change: when no trusted interpreter is present the launcher now fails closed rather than attempting to run an external tool from `PATH`.

### Testing
- Ran `cargo fmt -- --check`, which succeeded. 
- Attempted `cargo test` / `cargo build` under CI-like environment, but network access to `crates.io` is blocked (CONNECT tunnel 403) so tests/build that fetch dependencies could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a3c95a448320b99186934f66054e)

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## 개요

`main.rs` 파일의 런타임 검색 경로 및 분석 엔진 위치 지정 로직을 수정했습니다. 검색 범위를 좁혔고 폴백 동작을 단순화했습니다.

## 변경 사항

|코호트 / 파일|요약|
|---|---|
|**런타임 및 분석 엔진 로직** <br> `apps/desktop/src-tauri/src/main.rs`|`runtime_search_roots` 함수: 실행 파일 부모의 모든 상위 경로 반복 제거, 부모 디렉토리와 관련 리소스 경로만 추가. `analysis_command` 함수: 파이썬 분석 엔진 탐색 시 존재 확인을 `is_file()` 확인으로 변경. 폴백 경로에서 복잡한 "uv" 실행 명령을 `"__bandscope_missing_analysis_python__"` 자리 표시자와 빈 인수를 사용하는 최소 폴백으로 대체.|

## 예상 코드 리뷰 노력

🎯 2 (Simple) | ⏱️ ~12분

## 시

> 🐰 경로를 단순하게, 검색을 좁혀서,  
> 빈 공간을 채우는 자리 표시자와 함께,  
> 논리의 소음을 걷어내고,  
> 더 깔끔한 흐름으로 나아가네요.

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->