### PR TITLE
fix: include workflow files in secret scan gate

### DIFF
--- a/.github/workflows/secret-scan-gate.yml
+++ b/.github/workflows/secret-scan-gate.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Scan for common hardcoded secrets
         run: |
-          ! git grep -nE '(ghp_|gho_|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY)' -- . ':(exclude)package-lock.json' ':(exclude)node_modules/**' ':(exclude).github/workflows/**'
+          ! git grep -nE '(g[h]p_|g[h]o_|A[K]IA[0-9A-Z]{16}|A[I]za[0-9A-Za-z\-_]{35}|BEGIN (R[S]A|E[C]|OPENS[S]H|PGP) PRIVATE KEY)' -- . ':(exclude)package-lock.json' ':(exclude)node_modules/**'

--- a/.github/workflows/secret-scan-gate.yml
+++ b/.github/workflows/secret-scan-gate.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Scan for common hardcoded secrets
         run: |
-          ! git grep -nE '(g[h]p_|g[h]o_|A[K]IA[0-9A-Z]{16}|A[I]za[0-9A-Za-z\-_]{35}|BEGIN (R[S]A|E[C]|OPENS[S]H|PGP) PRIVATE KEY)' -- . ':(exclude)package-lock.json' ':(exclude)node_modules/**'
+          ! git grep -nE '(g[h]p_|g[h]o_|A[K]IA[0-9A-Z]{16}|A[I]za[0-9A-Za-z\-_]{35}|BEGIN (R[S]A|E[C]|OPENS[S]H|P[G]P) PRIVATE KEY)' -- . ':(exclude)package-lock.json' ':(exclude)node_modules/**'


### PR DESCRIPTION
### Motivation
- Restore secret-scanning coverage for GitHub Actions workflow YAMLs because the previous exclusion of `.github/workflows/**` created a blind spot that could allow credentials in workflow files to bypass the hardcoded-secret gate.

### Description
- Removed the explicit workflow-path exclusion from `.github/workflows/secret-scan-gate.yml` so `.github/workflows/**` is scanned again and updated the hardcoded-secret regex literals to safe character-class forms to avoid self-matching while preserving detection behavior (`g[h]p_`, `A[K]IA`, `A[I]za`, `R[S]A`, `E[C]`, `OPENS[S]H`).
- The only file changed is `.github/workflows/secret-scan-gate.yml` and the scan still excludes `package-lock.json` and `node_modules/**` to limit expected false positives.

### Testing
- Ran the `git grep -nE '(g[h]p_|g[h]o_|A[K]IA[0-9A-Z]{16}|A[I]za[0-9A-Za-z\-_]{35}|BEGIN (R[S]A|E[C]|OPENS[S]H|PGP) PRIVATE KEY)' -- . ':(exclude)package-lock.json' ':(exclude)node_modules/**'` scan which returned exit code 1 indicating no matches in the current tree.
- Ran `python3 scripts/checks/verify_supply_chain.py` which completed successfully and reported the supply-chain verification passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a2e8b4c083209c53469df31ff7c2)

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## Walkthrough

시크릿 스캔 게이트 워크플로우의 git grep 명령이 수정되었습니다. 정규식 패턴이 괄호 문자 클래스를 사용하도록 변경되고, 경로 제외 규칙이 단순화되었습니다. `.github/workflows/**` 제외 규칙이 제거되었습니다.

## Changes

|Cohort / File(s)|Summary|
|---|---|
|**Secret Scan Workflow Configuration** <br> `.github/workflows/secret-scan-gate.yml`|Git grep 정규식 패턴을 괄호 문자 클래스(예: `g[h]p_`, `A[K]IA`)로 변경하고, 경로 제외 규칙을 단순화(`.github/workflows/**` 제외 제거)|

## Estimated code review effort

🎯 2 (Simple) | ⏱️ ~8 minutes

## Poem

> 🐰 깊고 깊은 비밀들을 찾아내고,  
> 대괄호로 더욱 영리하게 변신하고,  
> 경로를 정리하여 깔끔하게 정돈하니,  
> 보안의 문이 더욱 튼튼해졌네요!  
> *오케이!* 🔐✨

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->