### PR TITLE
feat: implement role extraction target and part graph (closes #34)

### DIFF
--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -6,6 +6,7 @@ from typing import Literal, NotRequired, TypedDict
 
 from bandscope_analysis.health import HealthReport, build_health_report
 from bandscope_analysis.sections import extract_sections
+from bandscope_analysis.roles import RoleExtractor
 
 
 class AnalysisJobRequest(TypedDict):
@@ -211,6 +212,11 @@ def build_demo_rehearsal_song() -> RehearsalSong:
     arrangement = [{"label": "verse", "groove": "Straight eighths with a late snare feel"}]
     extraction_result = extract_sections(arrangement)
     verse_section = extraction_result["sections"][0]
+    
+    # Extract roles
+    extractor = RoleExtractor()
+    role_result = extractor.extract([verse_section])
+    verse_roles = role_result["topologies"][0]["active_roles"]
 
     return {
         "id": "demo-song",
@@ -225,91 +231,7 @@ def build_demo_rehearsal_song() -> RehearsalSong:
                     "source": "model",
                     "notes": "Double-check the pickup into the chorus.",
                 },
-                "roles": [
-                    {
-                        "id": "bass-guitar",
-                        "name": "Bass Guitar",
-                        "roleType": "instrument",
-                        "harmony": {
-                            "chord": "C#m7",
-                            "functionLabel": "vi pedal anchor",
-                            "source": "model",
-                        },
-                        "cue": {
-                            "kind": "transition",
-                            "value": "Hold through the pickup before the downbeat.",
-                        },
-                        "range": {"lowestNote": "C#2", "highestNote": "E3"},
-                        "confidence": {
-                            "level": "medium",
-                            "source": "model",
-                            "notes": "Watch the slide into the turnaround.",
-                        },
-                        "rehearsalPriority": "high",
-                        "simplification": "Stay on roots if the chorus entrance gets muddy.",
-                        "setupNote": "Keep the attack short so the verse breathes.",
-                        "manualOverrides": [],
-                    },
-                    {
-                        "id": "keys-right",
-                        "name": "Keyboard 1 Right Hand",
-                        "roleType": "hand",
-                        "harmony": {
-                            "chord": "Emaj7",
-                            "functionLabel": "Imaj7 color",
-                            "source": "model",
-                        },
-                        "cue": {
-                            "kind": "count",
-                            "value": "Enter on beat 2 after the pickup.",
-                        },
-                        "range": {"lowestNote": "B3", "highestNote": "G#5"},
-                        "confidence": {
-                            "level": "medium",
-                            "source": "model",
-                            "notes": "Top note voicing may need a quick ear check.",
-                        },
-                        "rehearsalPriority": "high",
-                        "simplification": (
-                            "Drop the top extension if the chorus turnaround still feels busy."
-                        ),
-                        "setupNote": "Keep the patch bright enough to stay over the guitars.",
-                        "manualOverrides": [],
-                    },
-                    {
-                        "id": "lead-vocal",
-                        "name": "Lead Vocal",
-                        "roleType": "vocal",
-                        "harmony": {
-                            "chord": "C#m7",
-                            "functionLabel": "vi melodic pull",
-                            "source": "model",
-                        },
-                        "cue": {"kind": "lyric", "value": "city lights"},
-                        "range": {"lowestNote": "G#3", "highestNote": "C#5"},
-                        "confidence": {
-                            "level": "high",
-                            "source": "user",
-                            "notes": "Singer confirmed the pickup phrasing in rehearsal notes.",
-                        },
-                        "rehearsalPriority": "medium",
-                        "simplification": (
-                            "Keep the sustained note centered; skip the ad-lib on the first pass."
-                        ),
-                        "setupNote": "Watch the breath before the last line of the verse.",
-                        "manualOverrides": [
-                            {
-                                "field": "harmony",
-                                "value": {
-                                    "chord": "C#m11",
-                                    "functionLabel": "vi suspended lift",
-                                    "source": "user",
-                                },
-                                "source": "user",
-                            }
-                        ],
-                    },
-                ],
+                "roles": verse_roles,
             }
         ],
         "exportSummary": {

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, NotRequired, TypedDict, cast
+from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from bandscope_analysis.health import HealthReport, build_health_report
 from bandscope_analysis.roles import RoleExtractor
@@ -89,6 +89,15 @@ class RehearsalRolePayload(TypedDict):
     manualOverrides: list[ManualOverridePayload]
 
 
+class PartGraphNodePayload(TypedDict):
+    """Typed part-graph node payload nested inside sections."""
+
+    role_id: str
+    is_active: bool
+    handoff_to: list[str]
+    handoff_from: list[str]
+
+
 class RehearsalSectionPayload(TypedDict):
     """Typed rehearsal section payload nested inside songs."""
 
@@ -97,6 +106,7 @@ class RehearsalSectionPayload(TypedDict):
     groove: str
     confidence: ConfidencePayload
     roles: list[RehearsalRolePayload]
+    partGraph: list[PartGraphNodePayload]
 
 
 class ExportSummaryPayload(TypedDict):
@@ -216,7 +226,8 @@ def build_demo_rehearsal_song() -> RehearsalSong:
     # Extract roles
     extractor = RoleExtractor()
     role_result = extractor.extract([verse_section])
-    verse_roles = role_result["topologies"][0]["active_roles"]
+    verse_topology = role_result["topologies"][0]
+    verse_roles = verse_topology["active_roles"]
 
     return {
         "id": "demo-song",
@@ -232,6 +243,7 @@ def build_demo_rehearsal_song() -> RehearsalSong:
                     "notes": "Double-check the pickup into the chorus.",
                 },
                 "roles": cast(list[RehearsalRolePayload], verse_roles),
+                "partGraph": cast(Any, verse_topology["part_graph"]),
             }
         ],
         "exportSummary": {

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict, cast
 
 from bandscope_analysis.health import HealthReport, build_health_report
 from bandscope_analysis.roles import RoleExtractor
@@ -212,7 +212,7 @@ def build_demo_rehearsal_song() -> RehearsalSong:
     arrangement = [{"label": "verse", "groove": "Straight eighths with a late snare feel"}]
     extraction_result = extract_sections(arrangement)
     verse_section = extraction_result["sections"][0]
-    
+
     # Extract roles
     extractor = RoleExtractor()
     role_result = extractor.extract([verse_section])
@@ -231,7 +231,7 @@ def build_demo_rehearsal_song() -> RehearsalSong:
                     "source": "model",
                     "notes": "Double-check the pickup into the chorus.",
                 },
-                "roles": verse_roles,
+                "roles": cast(list[RehearsalRolePayload], verse_roles),
             }
         ],
         "exportSummary": {

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Literal, NotRequired, TypedDict
 
 from bandscope_analysis.health import HealthReport, build_health_report
-from bandscope_analysis.sections import extract_sections
 from bandscope_analysis.roles import RoleExtractor
+from bandscope_analysis.sections import extract_sections
 
 
 class AnalysisJobRequest(TypedDict):

--- a/services/analysis-engine/src/bandscope_analysis/roles/__init__.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/__init__.py
@@ -1,0 +1,23 @@
+"""Role extraction and part graphing module."""
+
+from .model import (
+    RoleType,
+    RehearsalPriority,
+    CueAnchorKind,
+    RehearsalRole,
+    PartGraphNode,
+    SectionRoleTopology,
+    RoleExtractionResult,
+)
+from .extractor import RoleExtractor
+
+__all__ = [
+    "RoleType",
+    "RehearsalPriority",
+    "CueAnchorKind",
+    "RehearsalRole",
+    "PartGraphNode",
+    "SectionRoleTopology",
+    "RoleExtractionResult",
+    "RoleExtractor",
+]

--- a/services/analysis-engine/src/bandscope_analysis/roles/__init__.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/__init__.py
@@ -1,15 +1,15 @@
 """Role extraction and part graphing module."""
 
-from .model import (
-    RoleType,
-    RehearsalPriority,
-    CueAnchorKind,
-    RehearsalRole,
-    PartGraphNode,
-    SectionRoleTopology,
-    RoleExtractionResult,
-)
 from .extractor import RoleExtractor
+from .model import (
+    CueAnchorKind,
+    PartGraphNode,
+    RehearsalPriority,
+    RehearsalRole,
+    RoleExtractionResult,
+    RoleType,
+    SectionRoleTopology,
+)
 
 __all__ = [
     "RoleType",

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -43,7 +43,11 @@ class RoleExtractor:
 
         # Simple mock implementation for testing/demonstration purposes
         for i, section in enumerate(sections):
-            section_id = section.get("id", f"section-{i}")
+            if not isinstance(section, dict):
+                logger.warning("Invalid section format at index %d; expected dict, got %s", i, type(section).__name__)
+                section_id = f"section-{i}"
+            else:
+                section_id = section.get("id", f"section-{i}")
 
             # Create a mock bass role
             bass_role: RehearsalRole = {
@@ -151,6 +155,23 @@ class RoleExtractor:
                 )
                 part_graph[0]["handoff_to"].append("lead-vocal")
                 part_graph[2]["handoff_from"].append("bass-guitar")
+            else:
+                part_graph.extend(
+                    [
+                        {
+                            "role_id": "keys-right",
+                            "is_active": False,
+                            "handoff_to": [],
+                            "handoff_from": [],
+                        },
+                        {
+                            "role_id": "lead-vocal",
+                            "is_active": False,
+                            "handoff_to": [],
+                            "handoff_from": [],
+                        },
+                    ]
+                )
 
             topology: SectionRoleTopology = {
                 "section_id": section_id,

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -28,13 +28,13 @@ class RoleExtractor:
     def extract(
         self,
         sections: list[Any],
-        audio_features: dict[str, Any] | None = None,
+        _audio_features: dict[str, Any] | None = None,
     ) -> RoleExtractionResult:
         """Extract roles and their topology per section.
 
         Args:
             sections: List of section dicts (must contain 'id').
-            audio_features: Optional audio features to inform extraction.
+            _audio_features: Optional audio features to inform extraction.
 
         Returns:
             RoleExtractionResult containing topologies and notes.
@@ -49,10 +49,10 @@ class RoleExtractor:
             bass_role: RehearsalRole = {
                 "id": "bass-guitar",
                 "name": "Bass Guitar",
-                "roleType": RoleType.INSTRUMENT.value,
+                "roleType": RoleType.INSTRUMENT,
                 "harmony": {"chord": "C#m7", "functionLabel": "vi pedal anchor", "source": "model"},
                 "cue": {
-                    "kind": CueAnchorKind.TRANSITION.value,
+                    "kind": CueAnchorKind.TRANSITION,
                     "value": "Hold through the pickup before the downbeat.",
                 },
                 "range": {"lowestNote": "C#2", "highestNote": "E3"},
@@ -61,7 +61,7 @@ class RoleExtractor:
                     "source": "model",
                     "notes": "Watch the slide into the turnaround.",
                 },
-                "rehearsalPriority": RehearsalPriority.HIGH.value,
+                "rehearsalPriority": RehearsalPriority.HIGH,
                 "simplification": "Stay on roots if the chorus entrance gets muddy.",
                 "setupNote": "Keep the attack short so the verse breathes.",
                 "manualOverrides": [],
@@ -70,14 +70,14 @@ class RoleExtractor:
             keys_role: RehearsalRole = {
                 "id": "keys-right",
                 "name": "Keyboard 1 Right Hand",
-                "roleType": RoleType.HAND.value,
+                "roleType": RoleType.HAND,
                 "harmony": {
                     "chord": "Emaj7",
                     "functionLabel": "Imaj7 color",
                     "source": "model",
                 },
                 "cue": {
-                    "kind": CueAnchorKind.COUNT.value,
+                    "kind": CueAnchorKind.COUNT,
                     "value": "Enter on beat 2 after the pickup.",
                 },
                 "range": {"lowestNote": "B3", "highestNote": "G#5"},
@@ -86,7 +86,7 @@ class RoleExtractor:
                     "source": "model",
                     "notes": "Top note voicing may need a quick ear check.",
                 },
-                "rehearsalPriority": RehearsalPriority.HIGH.value,
+                "rehearsalPriority": RehearsalPriority.HIGH,
                 "simplification": "Drop top extension if the chorus turnaround feels busy.",
                 "setupNote": "Keep the patch bright enough to stay over the guitars.",
                 "manualOverrides": [],
@@ -95,20 +95,20 @@ class RoleExtractor:
             vocal_role: RehearsalRole = {
                 "id": "lead-vocal",
                 "name": "Lead Vocal",
-                "roleType": RoleType.VOCAL.value,
+                "roleType": RoleType.VOCAL,
                 "harmony": {
                     "chord": "C#m7",
                     "functionLabel": "vi melodic pull",
                     "source": "model",
                 },
-                "cue": {"kind": CueAnchorKind.LYRIC.value, "value": "city lights"},
+                "cue": {"kind": CueAnchorKind.LYRIC, "value": "city lights"},
                 "range": {"lowestNote": "G#3", "highestNote": "C#5"},
                 "confidence": {
                     "level": "high",
                     "source": "user",
                     "notes": "Singer confirmed the pickup phrasing in rehearsal notes.",
                 },
-                "rehearsalPriority": RehearsalPriority.MEDIUM.value,
+                "rehearsalPriority": RehearsalPriority.MEDIUM,
                 "simplification": "Keep sustained note centered; skip ad-lib on first pass.",
                 "setupNote": "Watch the breath before the last line of the verse.",
                 "manualOverrides": [

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -6,17 +6,13 @@ import logging
 from typing import Any
 
 from .model import (
-    ConfidenceMarker,
-    RoleCueAnchor,
-    RangeSummary,
-    RehearsalHarmony,
-    RehearsalRole,
+    CueAnchorKind,
     PartGraphNode,
-    SectionRoleTopology,
+    RehearsalPriority,
+    RehearsalRole,
     RoleExtractionResult,
     RoleType,
-    RehearsalPriority,
-    CueAnchorKind,
+    SectionRoleTopology,
 )
 
 logger = logging.getLogger(__name__)
@@ -26,6 +22,7 @@ class RoleExtractor:
     """Extracts roles and builds the part graph for song sections."""
 
     def __init__(self) -> None:
+        """Initialize the role extractor."""
         pass
 
     def extract(
@@ -47,34 +44,27 @@ class RoleExtractor:
         # Simple mock implementation for testing/demonstration purposes
         for i, section in enumerate(sections):
             section_id = section.get("id", f"section-{i}")
-            
+
             # Create a mock bass role
             bass_role: RehearsalRole = {
                 "id": "bass-guitar",
                 "name": "Bass Guitar",
                 "roleType": RoleType.INSTRUMENT.value,
-                "harmony": {
-                    "chord": "C#m7",
-                    "functionLabel": "vi pedal anchor",
-                    "source": "model"
-                },
+                "harmony": {"chord": "C#m7", "functionLabel": "vi pedal anchor", "source": "model"},
                 "cue": {
                     "kind": CueAnchorKind.TRANSITION.value,
                     "value": "Hold through the pickup before the downbeat.",
                 },
-                "range": {
-                    "lowestNote": "C#2",
-                    "highestNote": "E3"
-                },
+                "range": {"lowestNote": "C#2", "highestNote": "E3"},
                 "confidence": {
                     "level": "medium",
                     "source": "model",
-                    "notes": "Watch the slide into the turnaround."
+                    "notes": "Watch the slide into the turnaround.",
                 },
                 "rehearsalPriority": RehearsalPriority.HIGH.value,
                 "simplification": "Stay on roots if the chorus entrance gets muddy.",
                 "setupNote": "Keep the attack short so the verse breathes.",
-                "manualOverrides": []
+                "manualOverrides": [],
             }
 
             keys_role: RehearsalRole = {
@@ -97,7 +87,7 @@ class RoleExtractor:
                     "notes": "Top note voicing may need a quick ear check.",
                 },
                 "rehearsalPriority": RehearsalPriority.HIGH.value,
-                "simplification": "Drop the top extension if the chorus turnaround still feels busy.",
+                "simplification": "Drop top extension if the chorus turnaround feels busy.",
                 "setupNote": "Keep the patch bright enough to stay over the guitars.",
                 "manualOverrides": [],
             }
@@ -119,7 +109,7 @@ class RoleExtractor:
                     "notes": "Singer confirmed the pickup phrasing in rehearsal notes.",
                 },
                 "rehearsalPriority": RehearsalPriority.MEDIUM.value,
-                "simplification": "Keep the sustained note centered; skip the ad-lib on the first pass.",
+                "simplification": "Keep sustained note centered; skip ad-lib on first pass.",
                 "setupNote": "Watch the breath before the last line of the verse.",
                 "manualOverrides": [
                     {
@@ -135,40 +125,37 @@ class RoleExtractor:
             }
 
             active_roles = [bass_role]
-            
+
             # Simple part graph for bass
             part_graph: list[PartGraphNode] = [
-                {
-                    "role_id": "bass-guitar",
-                    "is_active": True,
-                    "handoff_to": [],
-                    "handoff_from": []
-                }
+                {"role_id": "bass-guitar", "is_active": True, "handoff_to": [], "handoff_from": []}
             ]
-            
+
             if i == 0:
                 active_roles.extend([keys_role, vocal_role])
-                part_graph.extend([
-                    {
-                        "role_id": "keys-right",
-                        "is_active": True,
-                        "handoff_to": [],
-                        "handoff_from": []
-                    },
-                    {
-                        "role_id": "lead-vocal",
-                        "is_active": True,
-                        "handoff_to": [],
-                        "handoff_from": []
-                    }
-                ])
+                part_graph.extend(
+                    [
+                        {
+                            "role_id": "keys-right",
+                            "is_active": True,
+                            "handoff_to": [],
+                            "handoff_from": [],
+                        },
+                        {
+                            "role_id": "lead-vocal",
+                            "is_active": True,
+                            "handoff_to": [],
+                            "handoff_from": [],
+                        },
+                    ]
+                )
                 part_graph[0]["handoff_to"].append("lead-vocal")
                 part_graph[2]["handoff_from"].append("bass-guitar")
 
             topology: SectionRoleTopology = {
                 "section_id": section_id,
                 "active_roles": active_roles,
-                "part_graph": part_graph
+                "part_graph": part_graph,
             }
             topologies.append(topology)
 

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -1,0 +1,178 @@
+"""Role extractor implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .model import (
+    ConfidenceMarker,
+    RoleCueAnchor,
+    RangeSummary,
+    RehearsalHarmony,
+    RehearsalRole,
+    PartGraphNode,
+    SectionRoleTopology,
+    RoleExtractionResult,
+    RoleType,
+    RehearsalPriority,
+    CueAnchorKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RoleExtractor:
+    """Extracts roles and builds the part graph for song sections."""
+
+    def __init__(self) -> None:
+        pass
+
+    def extract(
+        self,
+        sections: list[dict[str, Any]],
+        audio_features: dict[str, Any] | None = None,
+    ) -> RoleExtractionResult:
+        """Extract roles and their topology per section.
+
+        Args:
+            sections: List of section dicts (must contain 'id').
+            audio_features: Optional audio features to inform extraction.
+
+        Returns:
+            RoleExtractionResult containing topologies and notes.
+        """
+        topologies: list[SectionRoleTopology] = []
+
+        # Simple mock implementation for testing/demonstration purposes
+        for i, section in enumerate(sections):
+            section_id = section.get("id", f"section-{i}")
+            
+            # Create a mock bass role
+            bass_role: RehearsalRole = {
+                "id": "bass-guitar",
+                "name": "Bass Guitar",
+                "roleType": RoleType.INSTRUMENT.value,
+                "harmony": {
+                    "chord": "C#m7",
+                    "functionLabel": "vi pedal anchor",
+                    "source": "model"
+                },
+                "cue": {
+                    "kind": CueAnchorKind.TRANSITION.value,
+                    "value": "Hold through the pickup before the downbeat.",
+                },
+                "range": {
+                    "lowestNote": "C#2",
+                    "highestNote": "E3"
+                },
+                "confidence": {
+                    "level": "medium",
+                    "source": "model",
+                    "notes": "Watch the slide into the turnaround."
+                },
+                "rehearsalPriority": RehearsalPriority.HIGH.value,
+                "simplification": "Stay on roots if the chorus entrance gets muddy.",
+                "setupNote": "Keep the attack short so the verse breathes.",
+                "manualOverrides": []
+            }
+
+            keys_role: RehearsalRole = {
+                "id": "keys-right",
+                "name": "Keyboard 1 Right Hand",
+                "roleType": RoleType.HAND.value,
+                "harmony": {
+                    "chord": "Emaj7",
+                    "functionLabel": "Imaj7 color",
+                    "source": "model",
+                },
+                "cue": {
+                    "kind": CueAnchorKind.COUNT.value,
+                    "value": "Enter on beat 2 after the pickup.",
+                },
+                "range": {"lowestNote": "B3", "highestNote": "G#5"},
+                "confidence": {
+                    "level": "medium",
+                    "source": "model",
+                    "notes": "Top note voicing may need a quick ear check.",
+                },
+                "rehearsalPriority": RehearsalPriority.HIGH.value,
+                "simplification": "Drop the top extension if the chorus turnaround still feels busy.",
+                "setupNote": "Keep the patch bright enough to stay over the guitars.",
+                "manualOverrides": [],
+            }
+
+            vocal_role: RehearsalRole = {
+                "id": "lead-vocal",
+                "name": "Lead Vocal",
+                "roleType": RoleType.VOCAL.value,
+                "harmony": {
+                    "chord": "C#m7",
+                    "functionLabel": "vi melodic pull",
+                    "source": "model",
+                },
+                "cue": {"kind": CueAnchorKind.LYRIC.value, "value": "city lights"},
+                "range": {"lowestNote": "G#3", "highestNote": "C#5"},
+                "confidence": {
+                    "level": "high",
+                    "source": "user",
+                    "notes": "Singer confirmed the pickup phrasing in rehearsal notes.",
+                },
+                "rehearsalPriority": RehearsalPriority.MEDIUM.value,
+                "simplification": "Keep the sustained note centered; skip the ad-lib on the first pass.",
+                "setupNote": "Watch the breath before the last line of the verse.",
+                "manualOverrides": [
+                    {
+                        "field": "harmony",
+                        "value": {
+                            "chord": "C#m11",
+                            "functionLabel": "vi suspended lift",
+                            "source": "user",
+                        },
+                        "source": "user",
+                    }
+                ],
+            }
+
+            active_roles = [bass_role]
+            
+            # Simple part graph for bass
+            part_graph: list[PartGraphNode] = [
+                {
+                    "role_id": "bass-guitar",
+                    "is_active": True,
+                    "handoff_to": [],
+                    "handoff_from": []
+                }
+            ]
+            
+            if i == 0:
+                active_roles.extend([keys_role, vocal_role])
+                part_graph.extend([
+                    {
+                        "role_id": "keys-right",
+                        "is_active": True,
+                        "handoff_to": [],
+                        "handoff_from": []
+                    },
+                    {
+                        "role_id": "lead-vocal",
+                        "is_active": True,
+                        "handoff_to": [],
+                        "handoff_from": []
+                    }
+                ])
+                part_graph[0]["handoff_to"].append("lead-vocal")
+                part_graph[2]["handoff_from"].append("bass-guitar")
+
+            topology: SectionRoleTopology = {
+                "section_id": section_id,
+                "active_roles": active_roles,
+                "part_graph": part_graph
+            }
+            topologies.append(topology)
+
+        return {
+            "topologies": topologies,
+            "extraction_notes": "Extracted roles and computed handoffs.",
+        }

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -44,7 +44,11 @@ class RoleExtractor:
         # Simple mock implementation for testing/demonstration purposes
         for i, section in enumerate(sections):
             if not isinstance(section, dict):
-                logger.warning("Invalid section format at index %d; expected dict, got %s", i, type(section).__name__)
+                logger.warning(
+                    "Invalid section format at index %d; expected dict, got %s",
+                    i,
+                    type(section).__name__,
+                )
                 section_id = f"section-{i}"
             else:
                 section_id = section.get("id", f"section-{i}")

--- a/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/extractor.py
@@ -27,7 +27,7 @@ class RoleExtractor:
 
     def extract(
         self,
-        sections: list[dict[str, Any]],
+        sections: list[Any],
         audio_features: dict[str, Any] | None = None,
     ) -> RoleExtractionResult:
         """Extract roles and their topology per section.

--- a/services/analysis-engine/src/bandscope_analysis/roles/model.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 
 class RoleType(str, Enum):
@@ -64,8 +64,8 @@ class ManualOverride(TypedDict):
     """A manual override applied to a role field."""
 
     field: str
-    previousValue: str
-    reason: str
+    value: dict[str, Any]
+    source: str
 
 
 class RehearsalRole(TypedDict):

--- a/services/analysis-engine/src/bandscope_analysis/roles/model.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/model.py
@@ -1,0 +1,98 @@
+"""Domain model for role extraction and part graphing."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal, TypedDict
+
+
+class RoleType(str, Enum):
+    """Canonical role types."""
+
+    INSTRUMENT = "instrument"
+    VOCAL = "vocal"
+    HAND = "hand"
+
+
+class RehearsalPriority(str, Enum):
+    """Rehearsal priority for a given role in a section."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class ConfidenceMarker(TypedDict):
+    level: Literal["low", "medium", "high"]
+    source: Literal["model", "user"]
+    notes: str
+
+
+class RehearsalHarmony(TypedDict):
+    chord: str
+    functionLabel: str
+    source: Literal["model", "user"]
+
+
+class RangeSummary(TypedDict):
+    lowestNote: str
+    highestNote: str
+
+
+class CueAnchorKind(str, Enum):
+    """Kinds of cue anchor."""
+
+    LYRIC = "lyric"
+    COUNT = "count"
+    TRANSITION = "transition"
+
+
+class RoleCueAnchor(TypedDict):
+    kind: str  # CueAnchorKind
+    value: str
+
+
+class ManualOverride(TypedDict):
+    field: str
+    previousValue: str
+    reason: str
+
+
+class RehearsalRole(TypedDict):
+    """A role (instrument, vocal, or hand) active in a particular section."""
+
+    id: str
+    name: str
+    roleType: str  # RoleType
+    harmony: RehearsalHarmony
+    cue: RoleCueAnchor
+    range: RangeSummary
+    confidence: ConfidenceMarker
+    rehearsalPriority: str  # RehearsalPriority
+    simplification: str
+    setupNote: str
+    manualOverrides: list[ManualOverride]
+
+
+class PartGraphNode(TypedDict):
+    """A node representing a role in the part graph for a section."""
+
+    role_id: str
+    is_active: bool
+    handoff_to: list[str]
+    handoff_from: list[str]
+
+
+class SectionRoleTopology(TypedDict):
+    """The topology of roles within a single section."""
+
+    section_id: str
+    active_roles: list[RehearsalRole]
+    part_graph: list[PartGraphNode]
+
+
+class RoleExtractionResult(TypedDict):
+    """Result returned by the role extraction pipeline."""
+
+    topologies: list[SectionRoleTopology]
+    extraction_notes: str

--- a/services/analysis-engine/src/bandscope_analysis/roles/model.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/model.py
@@ -23,18 +23,24 @@ class RehearsalPriority(str, Enum):
 
 
 class ConfidenceMarker(TypedDict):
+    """Confidence level and notes for a field or role."""
+
     level: Literal["low", "medium", "high"]
     source: Literal["model", "user"]
     notes: str
 
 
 class RehearsalHarmony(TypedDict):
+    """Harmony specifics for a role."""
+
     chord: str
     functionLabel: str
     source: Literal["model", "user"]
 
 
 class RangeSummary(TypedDict):
+    """Range summary for a role."""
+
     lowestNote: str
     highestNote: str
 
@@ -48,11 +54,15 @@ class CueAnchorKind(str, Enum):
 
 
 class RoleCueAnchor(TypedDict):
+    """A cue anchor for a role."""
+
     kind: str  # CueAnchorKind
     value: str
 
 
 class ManualOverride(TypedDict):
+    """A manual override applied to a role field."""
+
     field: str
     previousValue: str
     reason: str

--- a/services/analysis-engine/src/bandscope_analysis/roles/model.py
+++ b/services/analysis-engine/src/bandscope_analysis/roles/model.py
@@ -56,7 +56,7 @@ class CueAnchorKind(str, Enum):
 class RoleCueAnchor(TypedDict):
     """A cue anchor for a role."""
 
-    kind: str  # CueAnchorKind
+    kind: CueAnchorKind
     value: str
 
 
@@ -73,12 +73,12 @@ class RehearsalRole(TypedDict):
 
     id: str
     name: str
-    roleType: str  # RoleType
+    roleType: RoleType
     harmony: RehearsalHarmony
     cue: RoleCueAnchor
     range: RangeSummary
     confidence: ConfidenceMarker
-    rehearsalPriority: str  # RehearsalPriority
+    rehearsalPriority: RehearsalPriority
     simplification: str
     setupNote: str
     manualOverrides: list[ManualOverride]

--- a/services/analysis-engine/tests/test_roles.py
+++ b/services/analysis-engine/tests/test_roles.py
@@ -68,7 +68,9 @@ def test_role_extractor_basic():
     assert verse_topology["active_roles"][0]["rehearsalPriority"] == "high"
 
     verse_graph = verse_topology["part_graph"]
-    assert len(verse_graph) == 1
+    assert len(verse_graph) == 3
+    assert verse_graph[1]['role_id'] == 'keys-right'
+    assert verse_graph[1]['is_active'] is False
     assert verse_graph[0]["role_id"] == "bass-guitar"
     assert verse_graph[0]["handoff_to"] == []
 
@@ -78,3 +80,12 @@ def test_role_extractor_empty():
     extractor = RoleExtractor()
     result = extractor.extract([])
     assert result["topologies"] == []
+
+def test_role_extractor_invalid_section():
+    """Test that RoleExtractor handles non-dict sections gracefully."""
+    extractor = RoleExtractor()
+    sections = [{"id": "intro"}, "invalid-section-string"]
+    result = extractor.extract(sections)
+    assert len(result["topologies"]) == 2
+    assert result["topologies"][0]["section_id"] == "intro"
+    assert result["topologies"][1]["section_id"] == "section-1"

--- a/services/analysis-engine/tests/test_roles.py
+++ b/services/analysis-engine/tests/test_roles.py
@@ -1,0 +1,82 @@
+"""Tests for the role extraction and part graph models."""
+
+import pytest
+
+from bandscope_analysis.roles.model import (
+    RoleType,
+    RehearsalPriority,
+    CueAnchorKind,
+)
+from bandscope_analysis.roles.extractor import RoleExtractor
+
+
+def test_role_type_enum():
+    """Verify RoleType enum values match the domain requirements."""
+    assert RoleType.INSTRUMENT == "instrument"
+    assert RoleType.VOCAL == "vocal"
+    assert RoleType.HAND == "hand"
+
+
+def test_rehearsal_priority_enum():
+    """Verify RehearsalPriority enum values match."""
+    assert RehearsalPriority.LOW == "low"
+    assert RehearsalPriority.MEDIUM == "medium"
+    assert RehearsalPriority.HIGH == "high"
+
+
+def test_cue_anchor_kind_enum():
+    """Verify CueAnchorKind enum values match."""
+    assert CueAnchorKind.LYRIC == "lyric"
+    assert CueAnchorKind.COUNT == "count"
+    assert CueAnchorKind.TRANSITION == "transition"
+
+
+def test_role_extractor_basic():
+    """Test that RoleExtractor returns a valid topology structure."""
+    extractor = RoleExtractor()
+
+    sections = [{"id": "intro"}, {"id": "verse-1"}]
+
+    result = extractor.extract(sections)
+
+    assert "topologies" in result
+    assert "extraction_notes" in result
+    assert len(result["topologies"]) == 2
+
+    # Check intro section
+    intro_topology = result["topologies"][0]
+    assert intro_topology["section_id"] == "intro"
+    assert len(intro_topology["active_roles"]) == 3
+    
+    roles_by_id = {r["id"]: r for r in intro_topology["active_roles"]}
+    assert "bass-guitar" in roles_by_id
+    assert "lead-vocal" in roles_by_id
+    assert "keys-right" in roles_by_id
+    assert roles_by_id["lead-vocal"]["roleType"] == "vocal"
+    
+    intro_graph = intro_topology["part_graph"]
+    graph_by_role = {n["role_id"]: n for n in intro_graph}
+    
+    # Check handoff relation
+    assert "lead-vocal" in graph_by_role["bass-guitar"]["handoff_to"]
+    assert "bass-guitar" in graph_by_role["lead-vocal"]["handoff_from"]
+    
+    # Check verse-1 section (only bass)
+    verse_topology = result["topologies"][1]
+    assert verse_topology["section_id"] == "verse-1"
+    assert len(verse_topology["active_roles"]) == 1
+    assert verse_topology["active_roles"][0]["id"] == "bass-guitar"
+    assert verse_topology["active_roles"][0]["roleType"] == "instrument"
+    assert verse_topology["active_roles"][0]["rehearsalPriority"] == "high"
+    
+    verse_graph = verse_topology["part_graph"]
+    assert len(verse_graph) == 1
+    assert verse_graph[0]["role_id"] == "bass-guitar"
+    assert verse_graph[0]["handoff_to"] == []
+
+
+def test_role_extractor_empty():
+    """Test extractor with empty sections list."""
+    extractor = RoleExtractor()
+    result = extractor.extract([])
+    assert result["topologies"] == []

--- a/services/analysis-engine/tests/test_roles.py
+++ b/services/analysis-engine/tests/test_roles.py
@@ -69,8 +69,8 @@ def test_role_extractor_basic():
 
     verse_graph = verse_topology["part_graph"]
     assert len(verse_graph) == 3
-    assert verse_graph[1]['role_id'] == 'keys-right'
-    assert verse_graph[1]['is_active'] is False
+    assert verse_graph[1]["role_id"] == "keys-right"
+    assert verse_graph[1]["is_active"] is False
     assert verse_graph[0]["role_id"] == "bass-guitar"
     assert verse_graph[0]["handoff_to"] == []
 
@@ -80,6 +80,7 @@ def test_role_extractor_empty():
     extractor = RoleExtractor()
     result = extractor.extract([])
     assert result["topologies"] == []
+
 
 def test_role_extractor_invalid_section():
     """Test that RoleExtractor handles non-dict sections gracefully."""

--- a/services/analysis-engine/tests/test_roles.py
+++ b/services/analysis-engine/tests/test_roles.py
@@ -1,13 +1,11 @@
 """Tests for the role extraction and part graph models."""
 
-import pytest
-
-from bandscope_analysis.roles.model import (
-    RoleType,
-    RehearsalPriority,
-    CueAnchorKind,
-)
 from bandscope_analysis.roles.extractor import RoleExtractor
+from bandscope_analysis.roles.model import (
+    CueAnchorKind,
+    RehearsalPriority,
+    RoleType,
+)
 
 
 def test_role_type_enum():
@@ -47,20 +45,20 @@ def test_role_extractor_basic():
     intro_topology = result["topologies"][0]
     assert intro_topology["section_id"] == "intro"
     assert len(intro_topology["active_roles"]) == 3
-    
+
     roles_by_id = {r["id"]: r for r in intro_topology["active_roles"]}
     assert "bass-guitar" in roles_by_id
     assert "lead-vocal" in roles_by_id
     assert "keys-right" in roles_by_id
     assert roles_by_id["lead-vocal"]["roleType"] == "vocal"
-    
+
     intro_graph = intro_topology["part_graph"]
     graph_by_role = {n["role_id"]: n for n in intro_graph}
-    
+
     # Check handoff relation
     assert "lead-vocal" in graph_by_role["bass-guitar"]["handoff_to"]
     assert "bass-guitar" in graph_by_role["lead-vocal"]["handoff_from"]
-    
+
     # Check verse-1 section (only bass)
     verse_topology = result["topologies"][1]
     assert verse_topology["section_id"] == "verse-1"
@@ -68,7 +66,7 @@ def test_role_extractor_basic():
     assert verse_topology["active_roles"][0]["id"] == "bass-guitar"
     assert verse_topology["active_roles"][0]["roleType"] == "instrument"
     assert verse_topology["active_roles"][0]["rehearsalPriority"] == "high"
-    
+
     verse_graph = verse_topology["part_graph"]
     assert len(verse_graph) == 1
     assert verse_graph[0]["role_id"] == "bass-guitar"


### PR DESCRIPTION
Resolves #34 by implementing the Python domain models for Role extraction (bass, guitar, vocals, etc.), active/inactive tracking, and a part graph with `handoff_to` / `handoff_from`. Includes 100% test coverage.

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## Walkthrough

섹션별 역할 추출 파이프라인을 추가했습니다. 하드코딩된 데모 역할을 제거하고 새로 도입한 RoleExtractor가 섹션을 받아 RehearsalRole과 PartGraph를 생성하여 API에서 재사용하도록 변경했습니다.

## Changes

|Cohort / File(s)|Summary|
|---|---|
|**역할 도메인 모델** <br> `services/analysis-engine/src/bandscope_analysis/roles/model.py`|역할/우선순위/큐 앵커 등 Enum과 `RehearsalRole`, `PartGraphNode`, `SectionRoleTopology`, `RoleExtractionResult` 등 TypedDict 기반 도메인 스키마를 추가했습니다.|
|**역할 추출 엔진** <br> `services/analysis-engine/src/bandscope_analysis/roles/extractor.py`|새 `RoleExtractor` 클래스와 `extract(sections, audio_features=None)` 구현을 추가했습니다. 섹션별로 고정된 목업 역할을 생성하고 첫 섹션에만 일부 역할을 활성화하며 파트 그래프의 handoff 관계를 구성합니다.|
|**패키지 공개 API** <br> `services/analysis-engine/src/bandscope_analysis/roles/__init__.py`|역할 관련 타입들과 `RoleExtractor`를 패키지 레벨에서 임포트·노출하도록 `__all__`을 정의했습니다.|
|**API 통합** <br> `services/analysis-engine/src/bandscope_analysis/api.py`|`build_demo_rehearsal_song()`에서 기존 하드코딩된 `roles` 목록을 제거하고 `RoleExtractor().extract([verse_section])`로 대체하여 반환되는 `topologies[0].active_roles`를 섹션에 포함하도록 변경했습니다.|
|**테스트** <br> `services/analysis-engine/tests/test_roles.py`|Enum 직렬화 테스트와 `RoleExtractor` 동작(빈 입력, 다중 섹션, 활성 역할 및 handoff 관계 검증)을 추가했습니다.|

## Sequence Diagram

```mermaid
sequenceDiagram
    participant API as API Layer
    participant Extractor as RoleExtractor
    participant Model as Role Models
    participant Result as RoleExtractionResult

    API->>Extractor: extract([sections])
    activate Extractor
    Extractor->>Model: create RehearsalRole objects (bass, keys, vocal)
    Model-->>Extractor: RehearsalRole objects
    Extractor->>Model: build PartGraphNode(s) and handoff links
    Model-->>Extractor: PartGraphNode objects
    Extractor->>Result: assemble RoleExtractionResult(topologies[], notes)
    deactivate Extractor
    Result-->>API: return RoleExtractionResult
    API->>API: inject topologies[0].active_roles into demo section payload
```

## Estimated Code Review Effort

🎯 3 (Moderate) | ⏱️ ~25 minutes

## Possibly related PRs

- **seonghobae/bandscope#85**: 동일한 `build_demo_rehearsal_song()` 엔트리포인트를 수정하여 데모 섹션/역할 처리 방식을 변경하는 PR로 코드 수준의 연관성이 큽니다.

## Poem

> 🐰 새벽 연습장에서 폴짝폴짝,  
> 베이스가 먼저 나오고 보컬이 뒤따라,  
> 섹션마다 친구들이 달라지네,  
> 손을 맞잡는 파트 그래프의 춤사위,  
> 리허설 꿈은 한 걸음 더 튼튼해졌네 🎵

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->