### PR TITLE
chore(security): resolve OSSF Scorecard alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: ci / build-and-test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,15 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: codeql
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,12 +8,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-review:
     name: dependency-review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -34,7 +34,7 @@ jobs:
     needs:
       - supplemental-inventory
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -59,8 +59,27 @@ jobs:
           name: bandscope-supply-chain-inventory
           path: supply-chain/supplemental-component-inventory.json
 
+  release-sbom:
+    name: attach-sbom-to-release
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs:
+      - sbom
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bandscope-sbom
+          
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bandscope-supply-chain-inventory
+          path: supply-chain
+          
       - name: Attach SBOM to GitHub Release
-        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -35,14 +35,12 @@ jobs:
         run: npm audit --workspaces --audit-level=high
       - name: Sync Python dependencies
         run: uv sync --project services/analysis-engine --group dev --frozen
-      - name: Install pip-audit
-        run: python -m pip install pip-audit==2.8.0
       - name: Export Python lock for audit
         working-directory: services/analysis-engine
         run: uv export --frozen --no-emit-project --format requirements-txt --no-hashes --output-file requirements-audit.txt
       - name: Audit Python dependencies
         working-directory: services/analysis-engine
-        run: python -m pip_audit -r requirements-audit.txt --strict --ignore-vuln GHSA-5239-wwwm-4pmq
+        run: uvx pip-audit==2.8.0 -r requirements-audit.txt --strict --ignore-vuln GHSA-5239-wwwm-4pmq
       - name: Install stable Rust toolchain
         run: rustup toolchain install stable --profile minimal
       - name: Install cargo-audit

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,12 +12,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   trivy-fs-scan:
     name: trivy-fs-scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Trivy filesystem scan


### PR DESCRIPTION
## Summary
- Drop top-level write permissions across all workflows
- Restrict 'security-events: write', 'contents: write', and 'pull-requests: write' strictly to the jobs that need them
- Upgrade 'security-audit.yml' to use 'uvx pip-audit' to resolve Pinned-Dependencies alert