### PR TITLE
fix(security): tighten YouTube URL validation to block redirect endpoints

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -875,9 +875,10 @@ fn is_supported_youtube_url(url: &str) -> bool {
 
     if host == "youtube.com" || host.ends_with(".youtube.com") {
         return parsed_url.path() == "/watch"
+            && parsed_url.query_pairs().filter(|(k, _)| k == "v").count() == 1
             && parsed_url
                 .query_pairs()
-                .any(|(key, value)| key == "v" && !value.trim().is_empty());
+                .any(|(k, v)| k == "v" && !v.trim().is_empty());
     }
 
     false

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -740,15 +740,7 @@ async fn import_youtube_url(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<ProjectBootstrapSummaryPayload, String> {
-    let parsed_url = match url::Url::parse(&url) {
-        Ok(u) => u,
-        Err(_) => return Err("Only standard YouTube URLs are supported.".to_string()),
-    };
-    if parsed_url.scheme() != "https" {
-        return Err("Only standard YouTube URLs are supported.".to_string());
-    }
-    let host = parsed_url.host_str().unwrap_or("").to_lowercase();
-    if host != "youtu.be" && host != "youtube.com" && !host.ends_with(".youtube.com") {
+    if !is_supported_youtube_url(&url) {
         return Err("Only standard YouTube URLs are supported.".to_string());
     }
 
@@ -780,8 +772,9 @@ async fn import_youtube_url(
                 .args(args)
                 .current_dir(working_dir)
                 .output()
-        })
-    ).await;
+        }),
+    )
+    .await;
 
     let output = spawn_result
         .map_err(|_| "YouTube import timed out.".to_string())?
@@ -794,11 +787,22 @@ async fn import_youtube_url(
 
     if parsed.get("ok").and_then(|v| v.as_bool()) == Some(true) {
         if let Some(metadata) = parsed.get("metadata") {
-            let filepath = metadata.get("filepath").and_then(|v| v.as_str()).unwrap_or("");
-            let title = metadata.get("title").and_then(|v| v.as_str()).unwrap_or("Unknown YouTube Audio");
+            let filepath = metadata
+                .get("filepath")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let title = metadata
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown YouTube Audio");
             let path = Path::new(filepath);
-            let metadata_fs = std::fs::metadata(path).map_err(|_| "Could not read downloaded audio file.".to_string())?;
-            let extension = path.extension().and_then(|v| v.to_str()).unwrap_or("m4a").to_string();
+            let metadata_fs = std::fs::metadata(path)
+                .map_err(|_| "Could not read downloaded audio file.".to_string())?;
+            let extension = path
+                .extension()
+                .and_then(|v| v.to_str())
+                .unwrap_or("m4a")
+                .to_string();
 
             let safe_title: String = title
                 .chars()
@@ -833,16 +837,50 @@ async fn import_youtube_url(
             store_bootstrap_source(&state, summary.clone());
             return Ok(summary);
         } else {
-            return Err(format!("YouTube import reported ok but missing metadata: {}", parsed.to_string()));
+            return Err(format!(
+                "YouTube import reported ok but missing metadata: {}",
+                parsed.to_string()
+            ));
         }
     }
 
     if let Some(err) = parsed.get("error") {
-        let msg = err.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error during YouTube import.");
+        let msg = err
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error during YouTube import.");
         return Err(msg.to_string());
     }
 
     Err("YouTube import failed with an unknown error.".to_string())
+}
+
+fn is_supported_youtube_url(url: &str) -> bool {
+    let parsed_url = match url::Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    if parsed_url.scheme() != "https" {
+        return false;
+    }
+
+    let host = parsed_url.host_str().unwrap_or("").to_lowercase();
+    if host == "youtu.be" {
+        let mut segments = match parsed_url.path_segments() {
+            Some(s) => s.filter(|segment| !segment.is_empty()),
+            None => return false,
+        };
+        return segments.next().is_some() && segments.next().is_none();
+    }
+
+    if host == "youtube.com" || host.ends_with(".youtube.com") {
+        return parsed_url.path() == "/watch"
+            && parsed_url
+                .query_pairs()
+                .any(|(key, value)| key == "v" && !value.trim().is_empty());
+    }
+
+    false
 }
 #[tauri::command]
 fn save_project(payload: Value) -> Result<(), String> {

--- a/services/analysis-engine/src/bandscope_analysis/youtube.py
+++ b/services/analysis-engine/src/bandscope_analysis/youtube.py
@@ -37,7 +37,7 @@ def validate_url(url: str) -> bool:
         if host == "youtube.com" or host.endswith(".youtube.com"):
             if parsed.path != "/watch":
                 return False
-            query = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+            query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
             video_ids = query.get("v", [])
             return len(video_ids) == 1 and bool(video_ids[0].strip())
 

--- a/services/analysis-engine/src/bandscope_analysis/youtube.py
+++ b/services/analysis-engine/src/bandscope_analysis/youtube.py
@@ -29,7 +29,19 @@ def validate_url(url: str) -> bool:
         if parsed.scheme != "https":
             return False
         host = parsed.netloc.lower().split(":")[0]
-        return host == "youtu.be" or host == "youtube.com" or host.endswith(".youtube.com")
+
+        if host == "youtu.be":
+            path = parsed.path.strip("/")
+            return bool(path) and "/" not in path
+
+        if host == "youtube.com" or host.endswith(".youtube.com"):
+            if parsed.path != "/watch":
+                return False
+            query = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+            video_ids = query.get("v", [])
+            return len(video_ids) == 1 and bool(video_ids[0].strip())
+
+        return False
     except Exception:
         return False
 

--- a/services/analysis-engine/tests/test_youtube.py
+++ b/services/analysis-engine/tests/test_youtube.py
@@ -25,6 +25,9 @@ def test_validate_url() -> None:
     assert validate_url("https://youtube.com/watch?v=") is False
     assert validate_url("https://youtu.be/") is False
     assert validate_url("https://youtu.be/123/extra") is False
+    assert validate_url("https://youtube.com/watch?v=123&v=456") is False
+    assert validate_url("https://youtube.com/watch?v=&v=456") is False
+    assert validate_url("https://youtube.com/watch?v=123&v=") is False
 
 
 def test_download_youtube_audio_invalid_url() -> None:

--- a/services/analysis-engine/tests/test_youtube.py
+++ b/services/analysis-engine/tests/test_youtube.py
@@ -17,8 +17,14 @@ def test_validate_url() -> None:
     assert validate_url("https://www.youtube.com/watch?v=123") is True
     assert validate_url("https://m.youtube.com/watch?v=123") is True
     assert validate_url("https://music.youtube.com/watch?v=123") is True
+    assert validate_url("https://www.youtube.com/watch?v=123&t=10") is True
     assert validate_url("http://youtube.com/watch?v=123") is False
     assert validate_url("https://vimeo.com/123") is False
+    assert validate_url("https://youtube.com/redirect?q=https://example.com") is False
+    assert validate_url("https://www.youtube.com/redirect?q=https://example.com") is False
+    assert validate_url("https://youtube.com/watch?v=") is False
+    assert validate_url("https://youtu.be/") is False
+    assert validate_url("https://youtu.be/123/extra") is False
 
 
 def test_download_youtube_audio_invalid_url() -> None:


### PR DESCRIPTION
### Motivation
- A previous change validated only the URL scheme and host, which allowed YouTube redirect-style endpoints (e.g. `/redirect?q=...`) to pass and enabled yt-dlp to follow attacker-controlled redirects. 
- The goal is to enforce canonical video endpoint shapes at both the IPC boundary and the analysis engine so only real YouTube video URLs are accepted.

### Description
- Added a Rust helper `is_supported_youtube_url` and replaced the prior host-only check in `import_youtube_url` to accept only `https://youtu.be/<video_id>` with a single non-empty path segment or `https://*.youtube.com/watch?v=<video_id>` with a non-empty `v` query parameter. 
- Hardened the Python `validate_url` in `services/analysis-engine/src/bandscope_analysis/youtube.py` to apply the same endpoint constraints before invoking `yt-dlp`. 
- Expanded `services/analysis-engine/tests/test_youtube.py` with negative tests that explicitly reject `/redirect` endpoints, empty `v` values, empty `youtu.be` paths, and extra path segments while preserving valid `watch` variants. 
- Kept existing error paths and messages unchanged so invalid inputs fail safely with the existing user-facing message.

### Testing
- Ran formatter with `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml` which completed successfully. 
- Ran Python unit tests with `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_youtube.py` and observed all tests passing (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7312a308883208eefbd8f911253fe)

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## 워크스루

YouTube URL 검증 로직을 강화하기 위해 데스크톱 앱과 백엔드 서비스에서 검증 프로세스를 재구성합니다. HTTPS 프로토콜, 도메인 형식(youtube.com/youtu.be), 올바른 쿼리 매개변수를 확인하는 새로운 검증 헬퍼 함수가 추가되며, 관련 테스트 케이스가 확장됩니다.

## 변경사항

|Cohort / File(s)|요약|
|---|---|
|**YouTube URL 검증 헬퍼** <br> `apps/desktop/src-tauri/src/main.rs`|새로운 `is_supported_youtube_url()` 함수 추가: HTTPS 검증, youtu.be의 단일 경로 세그먼트 확인, youtube.com의 `/watch?v=` 쿼리 매개변수 검증. `import_youtube_url` 함수가 이 헬퍼를 사용하도록 리팩터링.|
|**YouTube 검증 로직 강화** <br> `services/analysis-engine/src/bandscope_analysis/youtube.py`|`validate_url()` 함수의 검증 규칙 엄격화: youtu.be는 단일 경로 세그먼트만 허용, youtube.com은 정확히 `/watch` 경로와 유효한 `v` 쿼리 매개변수 필수.|
|**테스트 커버리지 확장** <br> `services/analysis-engine/tests/test_youtube.py`|추가 유효 패턴 검증(`/watch?v=123&t=10`), 거부 케이스 확대(리다이렉트 URL, 빈 `v` 매개변수, 잘못된 youtu.be 경로 형식).|

## 예상 코드 리뷰 노력

🎯 3 (보통) | ⏱️ ~20분

## 관련 가능성 있는 PR

- **seonghobae/bandscope#90**: YouTube URL 검증 및 import 흐름을 동일하게 수정하며, 백엔드 서비스와 데스크톱 앱 양쪽의 검증 로직을 변경하는 관련된 PR입니다.

## 시

> 🐰 유튜브 주소들을 점검하네,
> HTTPS, 경로, 변수까지 모두 확인하고,
> youtu.be와 youtube.com을 구분하며,
> 촘촘한 검증으로 안전하게 걸러낸다네! ✨

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->