### PR TITLE
fix: properly quote formula-prefixed CSV fields

### DIFF
--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -11,6 +11,7 @@ describe("export sanitization", () => {
 
   it("escapes CSV fields to prevent formula injection", () => {
     expect(escapeCsvField("=1+2")).toBe("'=1+2");
+    expect(escapeCsvField("=\n=HYPERLINK(\"http://evil\")")).toBe('"\'=\n=HYPERLINK(""http://evil"")"');
     expect(escapeCsvField("+SUM(A1)")).toBe("'+SUM(A1)");
     expect(escapeCsvField("-100")).toBe("'-100");
     expect(escapeCsvField("@cmd")).toBe("'@cmd");

--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -18,6 +18,7 @@ describe("export sanitization", () => {
     expect(escapeCsvField("Normal text")).toBe("Normal text");
     expect(escapeCsvField("Text, with comma")).toBe('"Text, with comma"');
     expect(escapeCsvField('Text with "quotes"')).toBe('"Text with ""quotes"""');
+    expect(escapeCsvField("Text with\rcarriage return")).toBe('"Text with\rcarriage return"');
   });
 });
 

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -18,7 +18,7 @@ export function escapeCsvField(value: string): string {
     escapedValue = `'${value}`;
   }
   // Enclose in double quotes if there's a comma, newline, or double quote
-  if (escapedValue.includes(",") || escapedValue.includes("\n") || escapedValue.includes('"')) {
+  if (escapedValue.includes(",") || escapedValue.includes("\n") || escapedValue.includes("\r") || escapedValue.includes('"')) {
     const escapedQuotes = escapedValue.replace(/"/g, '""');
     return `"${escapedQuotes}"`;
   }

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -12,16 +12,17 @@ export function sanitizeFilename(title: string): string {
 
 /** Documented. */
 export function escapeCsvField(value: string): string {
+  let escapedValue = value;
   // Prevent CSV formula injection by prefixing problematic leading characters with a single quote
   if (/^[=+\-@]/.test(value)) {
-    return `'${value}`;
+    escapedValue = `'${value}`;
   }
   // Enclose in double quotes if there's a comma, newline, or double quote
-  if (value.includes(",") || value.includes("\n") || value.includes('"')) {
-    const escapedQuotes = value.replace(/"/g, '""');
+  if (escapedValue.includes(",") || escapedValue.includes("\n") || escapedValue.includes('"')) {
+    const escapedQuotes = escapedValue.replace(/"/g, '""');
     return `"${escapedQuotes}"`;
   }
-  return value;
+  return escapedValue;
 }
 
 /** Documented. */


### PR DESCRIPTION
### Motivation
- A CSV export sanitizer returned early after prefixing fields that begin with formula characters (`=`, `+`, `-`, `@`), which skipped CSV quoting for commas/newlines/quotes and enabled row/column injection leading to unprefixed formula cells. 
- The intent is to neutralize leading formula characters while still ensuring the full field is safely quoted/escaped so it cannot split CSV structure when opened in a spreadsheet.

### Description
- Update `escapeCsvField` in `apps/desktop/src/lib/export.ts` to prefix formula-leading input first and then apply CSV quoting/escaping to the resulting value so comma/newline/quote cases remain contained in a single cell. 
- Add a regression unit test in `apps/desktop/src/lib/export.test.ts` that asserts a payload containing a newline plus a formula (`=\n=HYPERLINK(...)`) is serialized into one quoted cell with the leading single-quote intact. 
- No changes to CSV generation call sites were required; `generateCueSheetCsv` continues to map fields through `escapeCsvField`. 
- Security Notes: untrusted project strings (section/role/chord/cue/notes) are treated at the export boundary, the fix neutralizes leading formula characters and prevents CSV structural breakout, and the added test exercises a known bypass vector (newline + formula) to ensure safe failure.

### Testing
- Ran the desktop test suite with `npm run test --workspace @bandscope/desktop` and all tests and coverage checks passed (32 tests, 100% coverage). 
- A single-file run `npm run test --workspace @bandscope/desktop -- src/lib/export.test.ts` fails the workspace-wide 100% coverage gate when executed alone, but the full workspace test run succeeds. 
- The new regression test for the newline-based formula payload passes under the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7334b316c832096186af1e82e6270)