### PR TITLE
fix(ci): add repo flag to gh release upload

### DIFF
--- a/.github/workflows/build-baseline.yml
+++ b/.github/workflows/build-baseline.yml
@@ -315,7 +315,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$RELEASE_TAG" artifacts/*.zip artifacts/*.sha256 artifacts/*.manifest.txt --clobber
+        run: gh release upload "$RELEASE_TAG" artifacts/*.zip artifacts/*.sha256 artifacts/*.manifest.txt --clobber --repo ${{ github.repository }}
 
   attach-macos-release-artifact:
     name: release-artifact / macos
@@ -336,4 +336,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$RELEASE_TAG" artifacts/*.zip artifacts/*.sha256 artifacts/*.manifest.txt --clobber
+        run: gh release upload "$RELEASE_TAG" artifacts/*.zip artifacts/*.sha256 artifacts/*.manifest.txt --clobber --repo ${{ github.repository }}


### PR DESCRIPTION
Fixes the 'not a git repository' error in the attach artifacts jobs during release.