### PR TITLE
fix(ci): guard OSSF Scorecard on release branch

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -22,15 +22,21 @@ jobs:
         with:
           persist-credentials: false
       - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: ${{ github.ref == 'refs/heads/develop' }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           name: ossf-scorecard-results
           path: results.sarif
           retention-days: 5
       - uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           sarif_file: results.sarif
+      - name: Skip OSSF Scorecard on non-default branch
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: echo "OSSF Scorecard only supports the default branch; skipped for ${GITHUB_REF}."

--- a/scripts/checks/verify_supply_chain.py
+++ b/scripts/checks/verify_supply_chain.py
@@ -151,6 +151,11 @@ def verify_workflow_coverage() -> list[str]:
             for token in ["develop", "main", "push", "schedule", "ossf-scorecard"]
             if token not in scorecard
         )
+        if "main" in scorecard and "ossf/scorecard-action" in scorecard:
+            if "github.event.repository.default_branch" not in scorecard:
+                missing.append(
+                    "ossf scorecard workflow must guard Scorecard execution to the repository default branch"
+                )
     return missing
 
 

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -74,3 +74,42 @@ def test_supply_chain_check_accepts_repo_multi_arch_workflow(
     assert (
         "build workflow should not rely on macos-latest for architecture coverage" not in violations
     )
+
+
+def test_supply_chain_check_requires_ossf_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure OSSF Scorecard is not invoked on non-default release branches."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py", "verify_supply_chain_ossf_guard"
+    )
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ossf-scorecard.yml").write_text(
+        """
+name: ossf-scorecard
+on:
+  push:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: '30 1 * * 1'
+jobs:
+  analysis:
+    name: ossf-scorecard
+    steps:
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_workflow_coverage()
+
+    assert (
+        "ossf scorecard workflow must guard Scorecard execution to the repository default branch"
+        in violations
+    )


### PR DESCRIPTION
## Summary
- Guard OSSF Scorecard and SARIF upload steps so they only run on the repository default branch.
- Keep the main release-branch workflow green with an explicit skip step instead of invoking Scorecard where it is unsupported.
- Add supply-chain regression coverage for the default-branch guard.

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py`
- `python3 scripts/checks/verify_supply_chain.py`
- `python3 scripts/checks/security_gates.py`

## Security Notes
- Touches GitHub Actions supply-chain scanning only.
- Does not reduce required `main`/`develop` merge gates documented in `docs/security/github-required-checks.md`; OSSF Scorecard is not listed as a required protected-branch check.
- Preserves SHA-pinned third-party actions and least-privilege workflow permissions.
- Prevents false CI failure on `main` while retaining Scorecard execution on the default `develop` branch where the upstream action supports it.