### PR TITLE
chore: prepare v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+# Changelog
+
 ## [Unreleased]
 
-# Changelog
+## [0.1.2] - 2026-04-29
+
+### Changed
+- Aligned the packaged desktop app version with the release package metadata.
+
+### Fixed
+- Stabilized YouTube import fallback behavior in browser and desktop dev paths.
+- Guarded OSSF Scorecard execution so release-branch pushes skip unsupported non-default branch runs cleanly.
 
 ## [0.1.1] - 2026-04-28
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BandScope",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "identifier": "com.bandscope.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bandscope",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bandscope",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bandscope",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "engines": {
     "node": ">=22 <23"

--- a/services/analysis-engine/tests/test_release_metadata.py
+++ b/services/analysis-engine/tests/test_release_metadata.py
@@ -1,0 +1,43 @@
+"""Tests for repository release metadata consistency."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    """Return the repository root from the analysis-engine test directory."""
+    return Path(__file__).resolve().parents[3]
+
+
+def root_package_version() -> str:
+    """Return the root package version used for release tagging."""
+    package_json = json.loads((repo_root() / "package.json").read_text(encoding="utf-8"))
+    return str(package_json["version"])
+
+
+def test_package_lock_release_version_matches_root_package() -> None:
+    """Ensure the lockfile release metadata cannot drift from package.json."""
+    package_lock = json.loads((repo_root() / "package-lock.json").read_text(encoding="utf-8"))
+
+    assert package_lock["version"] == root_package_version()
+    assert package_lock["packages"][""]["version"] == root_package_version()
+
+
+def test_tauri_release_version_matches_root_package() -> None:
+    """Ensure the installable desktop app reports the release version."""
+    tauri_config = json.loads(
+        (repo_root() / "apps" / "desktop" / "src-tauri" / "tauri.conf.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert tauri_config["version"] == root_package_version()
+
+
+def test_changelog_contains_root_package_release_entry() -> None:
+    """Ensure release branches document the package version being shipped."""
+    changelog = (repo_root() / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert f"## [{root_package_version()}]" in changelog


### PR DESCRIPTION
## Summary
- Bump root release metadata to v0.1.2 and align the Tauri desktop bundle version.
- Add a release metadata regression test covering package-lock, Tauri, and changelog drift.
- Document the YouTube fallback and OSSF Scorecard release-branch fixes for v0.1.2.

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_release_metadata.py`
- `./scripts/harness/quickcheck.sh`
- `npm audit --workspaces --audit-level=high`
- Downloaded build-baseline macOS arm64 artifact for `3175d3884a6e3ac17028f0d4508bacf6f95d0717`, verified SHA256, mounted DMG, and launched `BandScope.app` successfully.

## Security Notes
- No new runtime file, URL, subprocess, IPC, WebView, update, model, cache, or export surface is added.
- Release metadata guard reduces the chance of shipping installers with stale user-visible app versions.
- Existing unsigned/not-notarized macOS Gatekeeper warning remains until Apple signing/notarization credentials are configured.