### PR TITLE
chore: prepare v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-29
+
+### Fixed
+- Published release assets through a tag-driven draft release flow so immutable GitHub Releases include desktop installers, checksums, SBOM, and supplemental inventory before publication.
+- Added a supply-chain regression guard that rejects post-publication release asset uploads.
+
 ## [0.1.2] - 2026-04-29
 
 ### Changed

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BandScope",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.bandscope.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bandscope",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bandscope",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bandscope",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "engines": {
     "node": ">=22 <23"


### PR DESCRIPTION
## Summary
- Bumps BandScope release metadata to v0.1.3 after the immutable-release publishing workflow fix landed.
- Aligns root npm metadata, lockfile metadata, and Tauri package version.
- Adds v0.1.3 changelog notes for the corrected draft-before-publish release asset flow.

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_release_metadata.py services/analysis-engine/tests/test_supply_chain_policy.py -q`
- `python3 scripts/checks/verify_supply_chain.py`
- `actionlint .github/workflows/build-baseline.yml .github/workflows/sbom.yml`
- `./scripts/harness/quickcheck.sh`
- `npm audit --workspaces --audit-level=high`

## Security Notes
- Attack surface: release metadata and public desktop package versioning.
- Trust boundary: no new runtime file, URL, subprocess, IPC, WebView, update, model, cache, or export surface is added.
- Mitigations: release metadata consistency is covered by regression tests, and release assets will be created by the already-merged tag-driven draft release flow.
- Remaining risk: v0.1.2 remains immutable and empty; v0.1.3 is the recovery release that should carry installable assets.
- Test points: metadata tests confirm root package, lockfile, Tauri version, and changelog stay aligned.