### PR TITLE
Close Pygments audit exception

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           name: ossf-scorecard-results
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2; SHA pinning retained as supply-chain attack mitigation.
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           name: ossf-scorecard-results
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2; SHA pinning retained as supply-chain attack mitigation.
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 peeled commit; SHA pinning retained as supply-chain attack mitigation.
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -35,12 +35,8 @@ jobs:
         run: npm audit --workspaces --audit-level=high
       - name: Sync Python dependencies
         run: uv sync --project services/analysis-engine --group dev --frozen
-      - name: Export Python lock for audit
-        working-directory: services/analysis-engine
-        run: uv export --frozen --no-emit-project --format requirements-txt --no-hashes --output-file requirements-audit.txt
       - name: Audit Python dependencies
-        working-directory: services/analysis-engine
-        run: uvx pip-audit==2.8.0 -r requirements-audit.txt --strict --ignore-vuln GHSA-5239-wwwm-4pmq
+        run: uv run --project services/analysis-engine --with pip-audit==2.8.0 pip-audit --local --strict
       - name: Install stable Rust toolchain
         run: rustup toolchain install stable --profile minimal
       - name: Install cargo-audit

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,7 +33,7 @@ jobs:
           limit-severities-for-sarif: true
           exit-code: '1'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2; SHA pinning retained as supply-chain attack mitigation.
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 peeled commit; SHA pinning retained as supply-chain attack mitigation.
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,7 +33,7 @@ jobs:
           limit-severities-for-sarif: true
           exit-code: '1'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2; SHA pinning retained as supply-chain attack mitigation.
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -99,9 +99,9 @@ Exceptions are allowed only when no patched version exists and the advisory is n
 - exceptions must be encoded in repo-controlled workflow/config (not ad-hoc local commands)
 - exceptions must be reviewed and removed once a patched version becomes available
 
-Current controlled exception:
+Current controlled exceptions:
 
-- `GHSA-5239-wwwm-4pmq` (`Pygments <=2.19.2`) in Python dev/test dependency path; no patched version is available at this time, impact is low/local-access ReDoS, and BandScope does not expose Pygments parsing on untrusted runtime input paths. The CI `security-audit` workflow applies a targeted ignore for this advisory only.
+- No Python vulnerability exceptions are active. `GHSA-5239-wwwm-4pmq` (`Pygments <2.20.0`) was removed by locking `Pygments` to `2.20.0`; the CI `security-audit` workflow must run `pip-audit --local --strict` against the synced `uv` environment without a targeted ignore for that advisory.
 - Cargo audit warnings for legacy `gtk3`, `glib`, and `fxhash` vulnerabilities (e.g. `RUSTSEC-2024-0413`, `RUSTSEC-2024-0429`, `RUSTSEC-2025-0057`) inherited through Tauri v2 `wry`/`webkit2gtk` integration are explicitly allowed. These are deep framework dependencies with no alternative, so they are documented exceptions and ignored by default.
 
 Tracked third-party deprecation signal:

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import importlib
 from pathlib import Path
 
 import pytest
@@ -106,8 +107,14 @@ def test_python_security_audit_does_not_ignore_patched_pygments_advisory() -> No
     assert "uv run --project services/analysis-engine --with pip-audit==2.8.0" in workflow
     assert "Pygments <2.20.0" in dependency_policy
     assert "pip-audit --local --strict" in dependency_policy
-    assert 'name = "pygments"\nversion = "2.20.0"' in python_lockfile
-    assert 'name = "pygments"\nversion = "2.19.2"' not in python_lockfile
+    tomllib = importlib.import_module("tomllib")
+    lock = tomllib.loads(python_lockfile)
+    packages = lock.get("package", [])
+    pygments = [package for package in packages if package.get("name") == "pygments"]
+
+    assert len(pygments) == 1
+    assert pygments[0].get("version") == "2.20.0"
+    assert all(package.get("version") != "2.19.2" for package in pygments)
 
 
 def test_supply_chain_check_requires_ossf_default_branch_guard(

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -105,6 +105,7 @@ def test_python_security_audit_does_not_ignore_patched_pygments_advisory() -> No
 
     assert "--ignore-vuln GHSA-5239-wwwm-4pmq" not in workflow
     assert "uv run --project services/analysis-engine --with pip-audit==2.8.0" in workflow
+    assert "pip-audit --local --strict" in workflow
     assert "Pygments <2.20.0" in dependency_policy
     assert "pip-audit --local --strict" in dependency_policy
     tomllib = importlib.import_module("tomllib")

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -89,6 +89,27 @@ def test_build_baseline_upload_artifact_pins_are_consistent() -> None:
     assert len(set(pins)) == 1
 
 
+def test_python_security_audit_does_not_ignore_patched_pygments_advisory() -> None:
+    """Ensure patched Python advisories are not left as stale audit ignores."""
+    repo_root = Path(__file__).resolve().parents[3]
+    workflow = (repo_root / ".github" / "workflows" / "security-audit.yml").read_text(
+        encoding="utf-8"
+    )
+    dependency_policy = (repo_root / "docs" / "security" / "dependency-policy.md").read_text(
+        encoding="utf-8"
+    )
+    python_lockfile = (repo_root / "services" / "analysis-engine" / "uv.lock").read_text(
+        encoding="utf-8"
+    )
+
+    assert "--ignore-vuln GHSA-5239-wwwm-4pmq" not in workflow
+    assert "uv run --project services/analysis-engine --with pip-audit==2.8.0" in workflow
+    assert "Pygments <2.20.0" in dependency_policy
+    assert "pip-audit --local --strict" in dependency_policy
+    assert 'name = "pygments"\nversion = "2.20.0"' in python_lockfile
+    assert 'name = "pygments"\nversion = "2.19.2"' not in python_lockfile
+
+
 def test_supply_chain_check_requires_ossf_default_branch_guard(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import re
 import importlib
+import re
 from pathlib import Path
 
 import pytest

--- a/services/analysis-engine/uv.lock
+++ b/services/analysis-engine/uv.lock
@@ -764,11 +764,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Locks `Pygments` to 2.20.0 and removes the stale `GHSA-5239-wwwm-4pmq` pip-audit exception.
- Runs Python dependency audit against the synced `uv` environment with `pip-audit --local --strict` to avoid resolver/ensurepip toolchain failures while keeping the strict gate.
- Updates `upload-sarif` SHA pins in `trivy` and `ossf-scorecard` to `github/codeql-action` v4.35.2 while preserving immutable SHA pinning.

Fixes part of #194.

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q` → 46 passed
- `python3 scripts/checks/verify_supply_chain.py` → passed
- `python3 scripts/checks/security_gates.py` → passed
- `python3 scripts/checks/verify_docs.py` → passed
- `uv run --project services/analysis-engine --with pip-audit==2.8.0 pip-audit --local --strict` → No known vulnerabilities found

## Security Notes
- No security gates were disabled or downgraded.
- The removed vulnerability exception had a patched version available; regression coverage now guards against reintroducing the stale ignore or vulnerable Pygments lock.
- GitHub Actions remain pinned to immutable SHAs; comments retain the reviewed action version for auditability.