### PR TITLE
Prevent checkout default-branch warnings

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   bandit-scan:
     name: Bandit Security Scan

--- a/.github/workflows/build-baseline.yml
+++ b/.github/workflows/build-baseline.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   build-windows-native:
     name: build / windows / amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   verify:
     name: ci / build-and-test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,11 @@ permissions:
   actions: read
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   analyze:
     name: codeql

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   dependency-review:
     name: dependency-review

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,6 +10,11 @@ on:
 
 permissions: read-all
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   analysis:
     name: ossf-scorecard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   release-preflight:
     name: release-preflight

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   supplemental-inventory:
     name: supply-chain-inventory

--- a/.github/workflows/secret-scan-gate.yml
+++ b/.github/workflows/secret-scan-gate.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   secret-scan:
     name: secret-scan-gate

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   audit:
     name: security-audit

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   trivy-fs-scan:
     name: trivy-fs-scan

--- a/scripts/checks/verify_supply_chain.py
+++ b/scripts/checks/verify_supply_chain.py
@@ -403,17 +403,22 @@ def workflow_top_level_env(content: str) -> dict[str, str]:
     env: dict[str, str] = {}
     lines = content.splitlines()
     for index, line in enumerate(lines):
-        if line != "env:":
+        line_without_comment = line.partition("#")[0].rstrip()
+        if line_without_comment != "env:":
             continue
         for env_line in lines[index + 1 :]:
-            if not env_line.strip() or env_line.lstrip().startswith("#"):
+            env_line_without_comment = env_line.partition("#")[0].rstrip()
+            if not env_line_without_comment.strip():
                 continue
-            if not env_line.startswith(" "):
+            if not env_line_without_comment.startswith(" "):
                 break
-            match = re.match(r"^\s{2}([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$", env_line)
+            match = re.match(
+                r"^\s+([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$",
+                env_line_without_comment,
+            )
             if match is None:
                 continue
-            value = match.group(2).split(" #", 1)[0].strip().strip('"\'')
+            value = match.group(2).strip().strip('"\'')
             env[match.group(1)] = value
         break
     return env
@@ -427,7 +432,10 @@ def verify_checkout_default_branch_guard() -> list[str]:
     )
     for path in workflow_paths:
         content = path.read_text(encoding="utf-8")
-        if "actions/checkout@" not in content:
+        content_without_comments = "\n".join(
+            line.partition("#")[0] for line in content.splitlines()
+        )
+        if "actions/checkout@" not in content_without_comments:
             continue
         env = workflow_top_level_env(content)
         if all(

--- a/scripts/checks/verify_supply_chain.py
+++ b/scripts/checks/verify_supply_chain.py
@@ -53,6 +53,15 @@ RELEASE_DOWNLOAD_DECOMPRESSION_VIOLATION = (
     "release artifact download must use skip-decompress: true and "
     "repo-owned extraction before asset validation"
 )
+CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION = (
+    "workflows using actions/checkout must set workflow-level "
+    "GIT_CONFIG_* init.defaultBranch env to avoid Git initial-branch warnings"
+)
+CHECKOUT_DEFAULT_BRANCH_GUARD_ENV = {
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "init.defaultBranch",
+    "GIT_CONFIG_VALUE_0": "develop",
+}
 OSSF_ARTIFACT_EXTRACTOR = "scripts/checks/extract_scorecard_artifact.py"
 RELEASE_ARTIFACT_EXTRACTOR = "scripts/release/extract_release_artifacts.py"
 OSSF_SARIF_NORMALIZER = "scripts/checks/normalize_scorecard_sarif.py"
@@ -386,6 +395,47 @@ def verify_pinned_actions() -> list[str]:
             ):
                 continue
             violations.append(f"{path}:{idx} -> workflow action must be pinned by SHA")
+    return violations
+
+
+def workflow_top_level_env(content: str) -> dict[str, str]:
+    """Return the simple top-level env mapping from a GitHub Actions workflow."""
+    env: dict[str, str] = {}
+    lines = content.splitlines()
+    for index, line in enumerate(lines):
+        if line != "env:":
+            continue
+        for env_line in lines[index + 1 :]:
+            if not env_line.strip() or env_line.lstrip().startswith("#"):
+                continue
+            if not env_line.startswith(" "):
+                break
+            match = re.match(r"^\s{2}([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$", env_line)
+            if match is None:
+                continue
+            value = match.group(2).split(" #", 1)[0].strip().strip('"\'')
+            env[match.group(1)] = value
+        break
+    return env
+
+
+def verify_checkout_default_branch_guard() -> list[str]:
+    """Return checkout workflows missing the Git default-branch warning guard."""
+    violations: list[str] = []
+    workflow_paths = sorted(Path(".github/workflows").glob("*.yml")) + sorted(
+        Path(".github/workflows").glob("*.yaml")
+    )
+    for path in workflow_paths:
+        content = path.read_text(encoding="utf-8")
+        if "actions/checkout@" not in content:
+            continue
+        env = workflow_top_level_env(content)
+        if all(
+            env.get(key) == value
+            for key, value in CHECKOUT_DEFAULT_BRANCH_GUARD_ENV.items()
+        ):
+            continue
+        violations.append(f"{path}: {CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION}")
     return violations
 
 
@@ -1546,6 +1596,7 @@ def main() -> int:
     violations: list[str] = []
     violations.extend(f"missing file: {item}" for item in verify_required_files())
     violations.extend(verify_pinned_actions())
+    violations.extend(verify_checkout_default_branch_guard())
     violations.extend(verify_dependabot_coverage())
     violations.extend(verify_workflow_coverage())
     violations.extend(verify_immutable_release_upload_policy())

--- a/scripts/checks/verify_supply_chain.py
+++ b/scripts/checks/verify_supply_chain.py
@@ -406,12 +406,20 @@ def workflow_top_level_env(content: str) -> dict[str, str]:
         line_without_comment = line.partition("#")[0].rstrip()
         if line_without_comment != "env:":
             continue
+        child_indent: int | None = None
         for env_line in lines[index + 1 :]:
             env_line_without_comment = env_line.partition("#")[0].rstrip()
             if not env_line_without_comment.strip():
                 continue
-            if not env_line_without_comment.startswith(" "):
+            indent = len(env_line_without_comment) - len(
+                env_line_without_comment.lstrip(" ")
+            )
+            if indent == 0:
                 break
+            if child_indent is None:
+                child_indent = indent
+            if indent != child_indent:
+                continue
             match = re.match(
                 r"^\s+([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$",
                 env_line_without_comment,
@@ -427,15 +435,19 @@ def workflow_top_level_env(content: str) -> dict[str, str]:
 def verify_checkout_default_branch_guard() -> list[str]:
     """Return checkout workflows missing the Git default-branch warning guard."""
     violations: list[str] = []
+    checkout_uses_pattern = re.compile(
+        r"^\s*-?\s*uses:\s*(?:[\"'])?actions/checkout@"
+    )
     workflow_paths = sorted(Path(".github/workflows").glob("*.yml")) + sorted(
         Path(".github/workflows").glob("*.yaml")
     )
     for path in workflow_paths:
         content = path.read_text(encoding="utf-8")
-        content_without_comments = "\n".join(
-            line.partition("#")[0] for line in content.splitlines()
+        has_checkout = any(
+            checkout_uses_pattern.search(line.partition("#")[0])
+            for line in content.splitlines()
         )
-        if "actions/checkout@" not in content_without_comments:
+        if not has_checkout:
             continue
         env = workflow_top_level_env(content)
         if all(

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -163,6 +163,36 @@ jobs:
     ]
 
 
+def test_supply_chain_check_ignores_commented_checkout_reference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure commented checkout references do not trigger guard enforcement."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_commented_checkout_reference",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+# - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - run: node --version
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
+
+
 def test_supply_chain_check_rejects_run_step_checkout_default_branch_guard(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -239,6 +269,39 @@ jobs:
         "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
         "initial-branch warnings"
     ]
+
+
+def test_supply_chain_check_accepts_checkout_default_branch_guard_comments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure top-level env comments do not break valid checkout warning guards."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_checkout_default_branch_guard_comments",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+env: # Git subprocess defaults inherited by actions/checkout.
+  GIT_CONFIG_COUNT: "1" # one key/value pair follows
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
 
 
 def test_supply_chain_check_accepts_checkout_default_branch_guard(

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -193,6 +193,36 @@ jobs:
     assert violations == []
 
 
+def test_supply_chain_check_ignores_run_step_checkout_reference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure run-step checkout text does not trigger guard enforcement."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_run_step_checkout_reference",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
+
+
 def test_supply_chain_check_rejects_run_step_checkout_default_branch_guard(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -253,6 +283,44 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   unguarded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == [
+        ".github/workflows/ci.yml: workflows using actions/checkout must set "
+        "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
+        "initial-branch warnings"
+    ]
+
+
+def test_supply_chain_check_rejects_top_level_nested_env_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure nested top-level env maps cannot satisfy the checkout warning guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_top_level_nested_env_checkout_default_branch_guard",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+env:
+  CONFIGS:
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: init.defaultBranch
+    GIT_CONFIG_VALUE_0: develop
+jobs:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -93,6 +93,171 @@ def test_build_baseline_upload_artifact_pins_are_consistent() -> None:
     assert len(set(pins)) == 1
 
 
+def test_supply_chain_check_requires_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure checkout workflows suppress Git initial-branch warnings at source."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_checkout_default_branch_guard",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == [
+        ".github/workflows/ci.yml: workflows using actions/checkout must set "
+        "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
+        "initial-branch warnings"
+    ]
+
+
+def test_supply_chain_check_rejects_commented_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure commented guard examples do not satisfy the checkout warning guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_commented_checkout_default_branch_guard",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+# env:
+#   GIT_CONFIG_COUNT: "1"
+#   GIT_CONFIG_KEY_0: init.defaultBranch
+#   GIT_CONFIG_VALUE_0: develop
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == [
+        ".github/workflows/ci.yml: workflows using actions/checkout must set "
+        "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
+        "initial-branch warnings"
+    ]
+
+
+def test_supply_chain_check_rejects_run_step_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure later shell text does not satisfy the checkout warning guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_run_step_checkout_default_branch_guard",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: develop
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == [
+        ".github/workflows/ci.yml: workflows using actions/checkout must set "
+        "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
+        "initial-branch warnings"
+    ]
+
+
+def test_supply_chain_check_rejects_nested_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure a single nested env block cannot satisfy the workflow guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_nested_checkout_default_branch_guard",
+    )
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: ci
+jobs:
+  guarded:
+    runs-on: ubuntu-latest
+    env:
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: init.defaultBranch
+      GIT_CONFIG_VALUE_0: develop
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  unguarded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == [
+        ".github/workflows/ci.yml: workflows using actions/checkout must set "
+        "workflow-level GIT_CONFIG_* init.defaultBranch env to avoid Git "
+        "initial-branch warnings"
+    ]
+
+
+def test_supply_chain_check_accepts_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure checked-in checkout workflows carry the warning guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_repo_checkout_default_branch_guard",
+    )
+    repo_root = Path(__file__).resolve().parents[3]
+
+    monkeypatch.chdir(repo_root)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
+
+
 def test_python_security_audit_does_not_ignore_patched_pygments_advisory() -> None:
     """Ensure patched Python advisories are not left as stale audit ignores."""
     repo_root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary
- Add a workflow-level Git `init.defaultBranch=develop` guard before checkout across workflows that use `actions/checkout`.
- Extend the supply-chain verifier with regression coverage for missing, commented, run-step, and nested-env false-pass cases.
- Keeps pinned action and security gate behavior unchanged while addressing #204.

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q`
- `uv run --project services/analysis-engine ruff check scripts/checks/verify_supply_chain.py services/analysis-engine/tests/test_supply_chain_policy.py`
- `python3 scripts/checks/verify_supply_chain.py`
- `python3 scripts/checks/security_gates.py`
- `./scripts/harness/quickcheck.sh`

Closes #204