### PR TITLE
🧪 파일명 새니타이제이션 엣지 케이스 테스트 보완

### DIFF
--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -9,6 +9,22 @@ describe("export sanitization", () => {
     expect(sanitizeFilename("")).toBe("export");
   });
 
+  it("handles directory traversal attempts", () => {
+    expect(sanitizeFilename("../../../etc/passwd")).toBe("_________etc_passwd");
+    expect(sanitizeFilename("..\\..\\windows\\system32")).toBe("______windows_system32");
+  });
+
+  it("handles Windows reserved characters", () => {
+    expect(sanitizeFilename("<>:\"/\\|?*")).toBe("_________");
+    expect(sanitizeFilename("file<name>with:reserved\"chars")).toBe("file_name_with_reserved_chars");
+  });
+
+  it("handles whitespace correctly", () => {
+    expect(sanitizeFilename("   ")).toBe("export");
+    expect(sanitizeFilename("\t\n")).toBe("export");
+    expect(sanitizeFilename("  leading and trailing  ")).toBe("leading and trailing");
+  });
+
   it("escapes CSV fields to prevent formula injection", () => {
     expect(escapeCsvField("=1+2")).toBe("'=1+2");
     expect(escapeCsvField("=\n=HYPERLINK(\"http://evil\")")).toBe('"\'=\n=HYPERLINK(""http://evil"")"');


### PR DESCRIPTION
🎯 **What:** Added tests for the `sanitizeFilename` function to cover edge cases like directory traversal attempts, Windows reserved characters, and whitespace-only strings.
📊 **Coverage:** Now tests for strings like `../../../etc/passwd`, `<>:"/\|?*`, and `   `.
✨ **Result:** Increased testing coverage and ensured `sanitizeFilename` reliably neutralizes these edge cases to prevent file-system vulnerabilities.

---
*PR created automatically by Jules for task [943327305654772103](https://jules.google.com/task/943327305654772103) started by @seonghobae*