### PR TITLE
ci: schedule PR review merge sweep

### DIFF
--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -1,0 +1,166 @@
+name: pr-review-merge-scheduler
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_prs:
+        description: Maximum number of open PRs to inspect in one run
+        required: false
+        default: "20"
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-review-merge-scheduler
+  cancel-in-progress: false
+
+jobs:
+  review-and-merge-ready-prs:
+    name: review and merge ready PRs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      DEFAULT_BRANCH: develop
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      MAX_PRS: ${{ github.event.inputs.max_prs || '20' }}
+    steps:
+      - name: Inspect review state and merge eligible PRs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+
+          unresolved_threads() {
+            local pr="$1"
+            gh api graphql \
+              -f owner="$owner" \
+              -f repo="$repo" \
+              -F number="$pr" \
+              -f query='
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                        }
+                      }
+                    }
+                  }
+                }' \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length'
+          }
+
+          required_checks_passed() {
+            local pr="$1"
+            local check_error
+            local checks_json
+            local check_status
+            local non_passing
+            check_error="$(mktemp)"
+
+            set +e
+            checks_json="$(gh pr checks "$pr" --required --json name,bucket,state 2>"$check_error")"
+            check_status="$?"
+            set -e
+
+            if [[ "$check_status" -ne 0 ]]; then
+              if [[ "$check_status" -eq 8 ]]; then
+                echo "PR #$pr required checks are still pending."
+              else
+                echo "PR #$pr required checks could not be read:"
+                cat "$check_error"
+              fi
+              rm -f "$check_error"
+              return 1
+            fi
+            rm -f "$check_error"
+
+            non_passing="$(jq '[.[] | select(.bucket != "pass")] | length' <<<"$checks_json")"
+            if [[ "$non_passing" -ne 0 ]]; then
+              echo "PR #$pr has required checks that are not passing:"
+              jq -r '.[] | select(.bucket != "pass") | "- \(.name): \(.state)"' <<<"$checks_json"
+              return 1
+            fi
+
+            return 0
+          }
+
+          request_review_once() {
+            local pr="$1"
+            local head="$2"
+            local review="$3"
+            local body
+            local marker
+            local has_marker
+            marker="<!-- bandscope-pr-review-merge-scheduler:${head} -->"
+
+            has_marker="$(gh pr view "$pr" --json comments --jq --arg marker "$marker" 'any(.comments[]?; .body | contains($marker))')"
+            if [[ "$has_marker" == "true" ]]; then
+              echo "PR #$pr already has a scheduler review request for $head."
+              return 0
+            fi
+
+            body="$(printf '%s\n%s\n\n%s\n' \
+              "$marker" \
+              "@coderabbitai review" \
+              "Scheduled PR review/merge pass found zero unresolved review threads, but this head is not approved yet (${review}). Please review this current head so the normal merge gate can decide it.")"
+            gh pr comment "$pr" --body "$body"
+          }
+
+          prs_json="$(gh pr list \
+            --base "$DEFAULT_BRANCH" \
+            --state open \
+            --limit "$MAX_PRS" \
+            --json number,title,headRefOid,reviewDecision,mergeStateStatus,isDraft)"
+
+          while IFS= read -r pr_json; do
+            pr="$(jq -r '.number' <<<"$pr_json")"
+            head="$(jq -r '.headRefOid' <<<"$pr_json")"
+            review="$(jq -r '.reviewDecision' <<<"$pr_json")"
+            merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_json")"
+            title="$(jq -r '.title' <<<"$pr_json")"
+
+            echo "Inspecting PR #$pr: $title"
+
+            unresolved="$(unresolved_threads "$pr")"
+            if [[ "$unresolved" -ne 0 ]]; then
+              echo "PR #$pr has $unresolved unresolved review thread(s); leaving it for code fixes."
+              continue
+            fi
+
+            if [[ "$review" != "APPROVED" ]]; then
+              request_review_once "$pr" "$head" "$review"
+              continue
+            fi
+
+            if ! required_checks_passed "$pr"; then
+              continue
+            fi
+
+            if [[ "$merge_state" == "DIRTY" ]]; then
+              echo "PR #$pr has merge conflicts; leaving it for manual conflict resolution."
+              continue
+            fi
+
+            if [[ "$merge_state" == "BEHIND" ]]; then
+              echo "PR #$pr is behind $DEFAULT_BRANCH; updating branch and waiting for fresh checks."
+              gh pr update-branch "$pr" || true
+              continue
+            fi
+
+            echo "PR #$pr is approved, thread-clean, and required checks passed; attempting merge."
+            if ! gh pr merge "$pr" --merge --delete-branch --match-head-commit "$head"; then
+              echo "Direct merge did not complete for PR #$pr; enabling auto-merge when allowed."
+              gh pr merge "$pr" --auto --merge --delete-branch --match-head-commit "$head" || true
+            fi
+          done < <(jq -c '.[] | select(.isDraft | not)' <<<"$prs_json")

--- a/docs/workflow/pr-review-merge-scheduler.md
+++ b/docs/workflow/pr-review-merge-scheduler.md
@@ -1,0 +1,33 @@
+# PR Review Merge Scheduler
+
+## Purpose
+
+The PR review merge scheduler keeps the open `develop` PR queue moving without bypassing repository rules.
+It runs hourly and can also be started manually from the `pr-review-merge-scheduler` workflow.
+
+## Behavior
+
+- Inspect up to 20 open, non-draft PRs targeting `develop` by default.
+- Skip PRs with unresolved review threads.
+- Request one CodeRabbit review per head SHA when a PR has zero unresolved threads but is not approved.
+- Check only GitHub-required checks before merge actions.
+- Update approved PRs that are behind `develop` and wait for fresh checks.
+- Merge only PRs that are approved, thread-clean, conflict-free, and passing required checks.
+- Fall back to GitHub auto-merge only when a direct normal merge does not complete.
+
+## Non-Goals
+
+- It does not generate code fixes.
+- It does not dismiss reviews.
+- It does not resolve review threads.
+- It does not use admin merge or ruleset bypass.
+- It does not weaken required checks, branch protection, or repository rulesets.
+
+## Security Notes
+
+- Attack surface: scheduled GitHub Actions automation with write access to PR comments, PR branch updates, and normal merges.
+- Trust boundary touched: GitHub repository governance, PR review state, status checks, and CodeRabbit review requests.
+- Realistic threats: spammed review comments, merging a PR with unresolved conversations, merging without required checks, or hiding conflicts behind automation.
+- Mitigations: idempotent per-head review comment marker, explicit unresolved-thread check, required-check verification through GitHub, conflict skip, normal merge only, and no admin bypass path.
+- Remaining risk: CodeRabbit and GitHub check state can be delayed or stale; the scheduler therefore only advances eligible PRs and leaves code-fix work to agents or maintainers.
+- Test points: `workflow_dispatch` dry run on a limited `max_prs`, PR with unresolved thread, PR needing review, approved behind PR, approved conflict-free PR, and approved dirty PR.


### PR DESCRIPTION
## Summary
- add an hourly/manual `pr-review-merge-scheduler` workflow for the open `develop` PR queue
- request one CodeRabbit review per head when a thread-clean PR is not yet approved
- update behind approved PRs and merge only approved, thread-clean PRs with passing required checks
- document scheduler limits, non-goals, and security notes

## Validation
- `ruby -e 'require "yaml"; doc=YAML.load_file(".github/workflows/pr-review-merge-scheduler.yml"); File.write("/tmp/pr-review-merge-scheduler.sh", doc["jobs"]["review-and-merge-ready-prs"]["steps"][0]["run"]); puts "workflow yaml ok"' && bash -n /tmp/pr-review-merge-scheduler.sh`\n- `python3 scripts/checks/verify_supply_chain.py`\n- `git diff --check`\n\n## Security Notes\n- Attack surface: scheduled GitHub Actions automation with write access to PR comments, branch updates, and normal merge operations.\n- Trust boundary: GitHub review state, required checks, and CodeRabbit review requests.\n- Mitigations: idempotent per-head review marker, unresolved-thread check, required-check verification, conflict skip, normal merge only, no admin bypass, no review dismissal.\n- Remaining risk: hosted review/check state can be delayed, so the workflow only advances eligible PRs and leaves code fixes to agents or maintainers.\n\n@coderabbitai review