### PR TITLE
🎨 Palette: Improve accessibility of priority icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Added focus visible styles for keyboard navigation
 **Learning:** Interactive inline buttons (like the chord editor) and scrollable regions with `tabIndex={0}` do not automatically get focus visible styles, meaning keyboard users tabbing through won't know they are focused on them. Unlike central `<Button />` components which bake focus states in, these custom inline interactive elements need explicit focus styling.
 **Action:** Always add explicit focus visible styles (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300`) to custom interactive elements and scrollable regions with `tabIndex={0}` for proper keyboard accessibility.
+
+## 2026-06-13 - Added screen reader text for tooltip divs
+**Learning:** When using `title` attributes on non-interactive elements like icon-only `div`s for tooltips, screen readers might not announce them properly because they aren't focusable. The visual tooltip is not enough for accessibility.
+**Action:** Always add a visually hidden `<span className="sr-only">[Tooltip Text]</span>` inside non-interactive elements that rely on a `title` attribute so that screen readers have text content to announce.

--- a/apps/desktop/src/features/workspace/SectionRoadmap.tsx
+++ b/apps/desktop/src/features/workspace/SectionRoadmap.tsx
@@ -116,6 +116,7 @@ export function SectionRoadmap({ song, activeRole, onSongUpdate }: SectionRoadma
                         )}
                       </div>
                       <div title={`${t("priorityLabel")}: ${role.rehearsalPriority}`} className="rounded-full border border-white/10 bg-white/10 p-1 shadow-sm">
+                        <span className="sr-only">{`${t("priorityLabel")}: ${role.rehearsalPriority}`}</span>
                         {getPriorityIcon(role.rehearsalPriority)}
                       </div>
                     </div>


### PR DESCRIPTION
💡 What: Added a visually hidden `span` (`<span className="sr-only">`) containing the priority label text inside the icon-only `div` in the SectionRoadmap component. Also documented this accessibility pattern in the palette journal.
🎯 Why: To ensure screen readers announce the rehearsal priority. Previously, the priority was only indicated by a visual icon and a `title` attribute on a `div`. Since `div`s are not inherently interactive or focusable, screen readers often fail to read their `title` attributes, making this information inaccessible to some users.
📸 Before/After: Visual appearance is completely unchanged (as intended, since the added text is visually hidden). The screen reader experience is improved.
♿ Accessibility: Ensures that essential status information (priority) is available to assistive technologies, complying with best practices for non-interactive visual elements.

---
*PR created automatically by Jules for task [9711139699180331562](https://jules.google.com/task/9711139699180331562) started by @seonghobae*