### PR TITLE
⚡ Bolt: Memoize SongStructure to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,6 @@
 
 **Learning:** Instantiating dictionaries with repeated heuristic calculation calls inside a loop over many elements causes significant slowdowns.
 **Action:** Build mock role definitions once per extraction call and reuse them while constructing section topologies.
+## 2026-06-13 - Memoize SongStructure timeline
+**Learning:** The SongStructure timeline component renders multiple DOM nodes for sections and re-rendered unnecessarily when the active role state changed in the parent Workspace.
+**Action:** Apply React.memo to static presentational components that receive stable props (like sections) but are siblings to highly interactive state (like role filtering).

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, memo } from "react";
 import type { RehearsalSong } from "@bandscope/shared-types";
 import { RoleSwitcher } from "./RoleSwitcher";
 import { SectionRoadmap } from "./SectionRoadmap";
@@ -27,7 +27,7 @@ function formatTimelineTime(totalSeconds: number): string {
 type Translator = ReturnType<typeof createTranslator>;
 
 /** Documented. */
-function SongStructure({ sections, t }: { sections: RehearsalSong["sections"]; t: Translator }) {
+const SongStructure = memo(function SongStructure({ sections, t }: { sections: RehearsalSong["sections"]; t: Translator }) {
   return (
     <section className="rounded-3xl border border-cyan-300/20 bg-slate-950/72 p-4 shadow-[0_20px_80px_rgba(0,0,0,0.24)]">
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -71,7 +71,7 @@ function SongStructure({ sections, t }: { sections: RehearsalSong["sections"]; t
       </div>
     </section>
   );
-}
+});
 
 /** Documented. */
 export function Workspace({ song, onSongUpdate }: WorkspaceProps) {


### PR DESCRIPTION
💡 **What:** Wrapped the `SongStructure` functional component in `apps/desktop/src/features/workspace/Workspace.tsx` with `React.memo()`.

🎯 **Why:** The `SongStructure` component renders a complex timeline map with multiple DOM nodes by mapping over the song sections. It is a sibling to highly interactive elements like the `RoleSwitcher` inside the `Workspace` component. When a user switches roles, the `Workspace` state changes and triggers a re-render. Because `SongStructure` only depends on the stable `sections` prop (and the stable translator `t`), it was re-rendering unnecessarily on every role switch. Memoizing it prevents this overhead.

📊 **Impact:** Eliminates unnecessary React tree reconciliation and DOM node updates for the timeline section whenever the user interacts with the dashboard's filtering and active states. This makes interactions feel snappier, especially for songs with many sections.

🔬 **Measurement:** Verify by running the tests (`npm run test --workspace=apps/desktop`), checking that functionality remains intact. In a real environment, React DevTools Profiler would show `SongStructure` skipping renders when `activeRole` changes.

---
*PR created automatically by Jules for task [7533144511654676286](https://jules.google.com/task/7533144511654676286) started by @seonghobae*