### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix CSV formula injection bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - CSV Formula Injection whitespace bypass
+**Vulnerability:** CSV formula injection mitigation was naive, missing leading whitespace, tabs, and newlines.
+**Learning:** Checking `/^[=+\-@]/` is not sufficient, as OWASP states that spaces and tabs before the formula triggers will also execute the formula in applications like Excel.
+**Prevention:** Use a regex that allows leading whitespace (e.g. `/^[\s\uFEFF\xA0]*[=+\-@\t\r\n]/`) and include standalone tabs or new lines which are also injection vectors.

--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -54,6 +54,12 @@ describe("export sanitization", () => {
       expect(escapeCsvField("+SUM(A1)")).toBe("'+SUM(A1)");
       expect(escapeCsvField("-100")).toBe("'-100");
       expect(escapeCsvField("@cmd")).toBe("'@cmd");
+
+      // Prevent bypasses using leading whitespace or newlines
+      expect(escapeCsvField(" =1+2")).toBe("' =1+2");
+      expect(escapeCsvField("\t+SUM(A1)")).toBe("'\t+SUM(A1)");
+      expect(escapeCsvField("\n-100")).toBe("\"'\n-100\"");
+      expect(escapeCsvField("\r@cmd")).toBe("\"'\r@cmd\"");
     });
 
     it("handles combined scenarios: formula injection with structural characters", () => {

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -14,7 +14,7 @@ export function sanitizeFilename(title: string): string {
 export function escapeCsvField(value: string): string {
   let escapedValue = value;
   // Prevent CSV formula injection by prefixing problematic leading characters with a single quote
-  if (/^[=+\-@]/.test(value)) {
+  if (/^[\s\uFEFF\xA0]*[=+\-@\t\r\n]/.test(value)) {
     escapedValue = `'${value}`;
   }
   // Enclose in double quotes if there's a comma, newline, or double quote


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** CSV formula injection (CSV Injection) bypass via leading whitespace. The original check only looked for formula triggers (`=, +, -, @`) at the absolute beginning of the string. Attackers could bypass this by inserting spaces, tabs, or newlines before the trigger character, causing Excel and other spreadsheet applications to still execute the formula.
🎯 **Impact:** If an attacker can control the input of a field that ends up in a CSV export, they could execute arbitrary code on the victim's machine by injecting a malicious formula.
🔧 **Fix:** Updated the regex in `escapeCsvField` (`apps/desktop/src/lib/export.ts`) to `^[\s\uFEFF\xA0]*[=+\-@\t\r\n]`. This handles leading whitespace and includes tab/carriage return characters which are also valid trigger vectors. Added corresponding test cases.
✅ **Verification:** Run `npm run check` in the project root to verify all tests, linters, and typechecks pass.

---
*PR created automatically by Jules for task [10280904008091627318](https://jules.google.com/task/10280904008091627318) started by @seonghobae*