### PR TITLE
Fix OSSF Scorecard checkout guard placement

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,11 +10,6 @@ on:
 
 permissions: read-all
 
-env:
-  GIT_CONFIG_COUNT: "1"
-  GIT_CONFIG_KEY_0: init.defaultBranch
-  GIT_CONFIG_VALUE_0: develop
-
 jobs:
   analysis:
     name: ossf-scorecard
@@ -24,6 +19,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: develop
         with:
           persist-credentials: false
       - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
@@ -49,6 +48,10 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: develop
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/scripts/checks/verify_supply_chain.py
+++ b/scripts/checks/verify_supply_chain.py
@@ -51,6 +51,9 @@ OSSF_PUBLISH_USES_ONLY_VIOLATION = (
     "ossf scorecard publishing job must only contain uses steps; split run steps "
     "into a separate non-publishing job"
 )
+OSSF_PUBLISH_GLOBAL_CONFIG_VIOLATION = (
+    "ossf scorecard publishing workflow must not contain top-level env or defaults"
+)
 OSSF_DOWNLOAD_DECOMPRESSION_VIOLATION = (
     "ossf scorecard artifact download must use skip-decompress: true and "
     "repo-owned extraction before normalization"
@@ -62,6 +65,10 @@ RELEASE_DOWNLOAD_DECOMPRESSION_VIOLATION = (
 CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION = (
     "workflows using actions/checkout must set workflow-level "
     "GIT_CONFIG_* init.defaultBranch env to avoid Git initial-branch warnings"
+)
+OSSF_CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION = (
+    "ossf scorecard checkout steps must set step-level GIT_CONFIG_* "
+    "init.defaultBranch env to avoid Scorecard global env/defaults"
 )
 CHECKOUT_DEFAULT_BRANCH_GUARD_ENV = {
     "GIT_CONFIG_COUNT": "1",
@@ -233,6 +240,28 @@ def step_with_value_from_block(
         if match:
             return match.group("value").strip().strip("'\"")
     return None
+
+
+def step_env_from_block(step_lines: list[str], step_indent: int) -> dict[str, str]:
+    """Return a workflow step ``env`` mapping from a step block."""
+    env: dict[str, str] = {}
+    env_indent: int | None = None
+    for step_line in step_lines:
+        stripped = step_line.partition("#")[0].rstrip()
+        if not stripped.strip():
+            continue
+        indent = len(step_line) - len(step_line.lstrip(" "))
+        if env_indent is None:
+            if indent > step_indent and stripped.strip() == "env:":
+                env_indent = indent
+            continue
+        if indent <= env_indent:
+            break
+        match = re.match(r"^\s+([A-Za-z_][A-Za-z0-9_]*):\s*(.*?)\s*$", stripped)
+        if match is None:
+            continue
+        env[match.group(1)] = match.group(2).strip().strip("\"'")
+    return env
 
 
 def logical_workflow_lines(content: str) -> list[tuple[int, str]]:
@@ -441,6 +470,42 @@ def workflow_top_level_env(content: str) -> dict[str, str]:
     return env
 
 
+def workflow_top_level_key_lines(content: str, keys: set[str]) -> list[tuple[int, str]]:
+    """Return top-level workflow key line numbers for ``keys``."""
+    key_lines: list[tuple[int, str]] = []
+    for idx, line in enumerate(content.splitlines(), start=1):
+        line_without_comment = line.partition("#")[0].rstrip()
+        if not line_without_comment.strip():
+            continue
+        if len(line_without_comment) - len(line_without_comment.lstrip(" ")) != 0:
+            continue
+        key = line_without_comment.partition(":")[0].strip()
+        if key in keys:
+            key_lines.append((idx, key))
+    return key_lines
+
+
+def workflow_publishes_scorecard_results(content: str) -> bool:
+    """Return whether a workflow publishes OSSF Scorecard results."""
+    workflow_body = "\n".join(
+        line.partition("#")[0] for line in content.splitlines()
+    )
+    return (
+        "ossf/scorecard-action" in workflow_body
+        and "publish_results:" in workflow_body
+    )
+
+
+def checkout_step_has_default_branch_guard(
+    step_lines: list[str], step_indent: int
+) -> bool:
+    """Return whether a checkout step carries the Git default branch env guard."""
+    env = step_env_from_block(step_lines, step_indent)
+    return all(
+        env.get(key) == value for key, value in CHECKOUT_DEFAULT_BRANCH_GUARD_ENV.items()
+    )
+
+
 def verify_checkout_default_branch_guard() -> list[str]:
     """Return checkout workflows missing the Git default-branch warning guard."""
     violations: list[str] = []
@@ -455,6 +520,26 @@ def verify_checkout_default_branch_guard() -> list[str]:
             for line in content.splitlines()
         )
         if not has_checkout:
+            continue
+        if workflow_publishes_scorecard_results(content):
+            checkout_steps = [
+                (step_indent, step_lines)
+                for _, step_indent, step_lines in workflow_step_blocks(
+                    content.splitlines()
+                )
+                if any(
+                    checkout_uses_pattern.search(step_line.partition("#")[0])
+                    for step_line in step_lines
+                )
+            ]
+            if all(
+                checkout_step_has_default_branch_guard(step_lines, step_indent)
+                for step_indent, step_lines in checkout_steps
+            ):
+                continue
+            violations.append(
+                f"{path}: {OSSF_CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION}"
+            )
             continue
         env = workflow_top_level_env(content)
         if all(
@@ -514,6 +599,17 @@ def ossf_scorecard_publish_restriction_violations(
             else:
                 violations.append(
                     f"{path}:{start_line or 1} -> {OSSF_PUBLISH_USES_ONLY_VIOLATION}"
+                )
+
+    if workflow_publishes_scorecard_results(content):
+        for line_number, _ in workflow_top_level_key_lines(
+            content, {"env", "defaults"}
+        ):
+            if path is None:
+                violations.append(OSSF_PUBLISH_GLOBAL_CONFIG_VIOLATION)
+            else:
+                violations.append(
+                    f"{path}:{line_number} -> {OSSF_PUBLISH_GLOBAL_CONFIG_VIOLATION}"
                 )
 
     for idx, line in enumerate(content.splitlines(), start=1):

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -389,6 +389,138 @@ def test_supply_chain_check_accepts_checkout_default_branch_guard(
     assert violations == []
 
 
+def test_supply_chain_check_accepts_scorecard_step_level_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure Scorecard can avoid global env while still guarding checkout."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_scorecard_step_level_checkout_default_branch_guard",
+    )
+    publish_guard = supply_chain.OSSF_DEFAULT_BRANCH_PUBLISH_GUARD.partition(": ")[2]
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ossf-scorecard.yml").write_text(
+        """
+name: ossf-scorecard
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  analysis:
+    name: ossf-scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: develop
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          publish_results: PUBLISH_GUARD
+  scorecard-sarif-upload:
+    name: scorecard-sarif-upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: develop
+""".strip().replace("PUBLISH_GUARD", publish_guard),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
+
+
+def test_supply_chain_check_rejects_scorecard_missing_checkout_default_branch_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure Scorecard checkout steps require the step-level Git guard."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_scorecard_missing_checkout_default_branch_guard",
+    )
+    publish_guard = supply_chain.OSSF_DEFAULT_BRANCH_PUBLISH_GUARD.partition(": ")[2]
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ossf-scorecard.yml").write_text(
+        """
+name: ossf-scorecard
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  analysis:
+    name: ossf-scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          publish_results: PUBLISH_GUARD
+""".strip().replace("PUBLISH_GUARD", publish_guard),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert any(
+        supply_chain.OSSF_CHECKOUT_DEFAULT_BRANCH_GUARD_VIOLATION in violation
+        for violation in violations
+    )
+
+
+def test_supply_chain_check_ignores_scorecard_publish_mentions_in_comments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure comment text does not make a workflow look like Scorecard publish."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_scorecard_publish_comment_mentions",
+    )
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "checkout.yml").write_text(
+        """
+name: checkout
+on:
+  pull_request:
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      # uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+      # publish_results: true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_checkout_default_branch_guard()
+
+    assert violations == []
+
+
 def test_python_security_audit_does_not_ignore_patched_pygments_advisory() -> None:
     """Ensure patched Python advisories are not left as stale audit ignores."""
     repo_root = Path(__file__).resolve().parents[3]
@@ -532,6 +664,101 @@ jobs:
 
     assert (
         "ossf scorecard publish_results must use the repository default branch guard" in violations
+    )
+
+
+def test_supply_chain_check_rejects_scorecard_global_env_when_publishing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure Scorecard publish workflows do not use workflow-level env."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_scorecard_global_env",
+    )
+    publish_guard = supply_chain.OSSF_DEFAULT_BRANCH_PUBLISH_GUARD.partition(": ")[2]
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ossf-scorecard.yml").write_text(
+        """
+name: ossf-scorecard
+on:
+  push:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: '30 1 * * 1'
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+jobs:
+  analysis:
+    name: ossf-scorecard
+    steps:
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          publish_results: PUBLISH_GUARD
+""".strip().replace("PUBLISH_GUARD", publish_guard),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_workflow_coverage()
+
+    assert any(
+        "ossf scorecard publishing workflow must not contain top-level env or defaults" in violation
+        for violation in violations
+    )
+
+
+def test_supply_chain_check_rejects_scorecard_global_defaults_when_publishing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ensure Scorecard publish workflows do not use workflow-level defaults."""
+    supply_chain = load_module(
+        "scripts/checks/verify_supply_chain.py",
+        "verify_supply_chain_scorecard_global_defaults",
+    )
+    publish_guard = supply_chain.OSSF_DEFAULT_BRANCH_PUBLISH_GUARD.partition(": ")[2]
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ossf-scorecard.yml").write_text(
+        """
+name: ossf-scorecard
+on:
+  push:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: '30 1 * * 1'
+defaults:
+  run:
+    shell: bash
+jobs:
+  analysis:
+    name: ossf-scorecard
+    steps:
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          publish_results: PUBLISH_GUARD
+""".strip().replace("PUBLISH_GUARD", publish_guard),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    violations = supply_chain.verify_workflow_coverage()
+
+    assert any(
+        "ossf scorecard publishing workflow must not contain top-level env or defaults" in violation
+        for violation in violations
     )
 
 


### PR DESCRIPTION
## Summary
- move the Git default-branch checkout guard from workflow-level `env` to each OSSF Scorecard checkout step
- keep Scorecard publishing workflows free of top-level `env` and `defaults`
- teach the supply-chain verifier to allow the Scorecard-specific step-level guard while failing Scorecard publish workflows that reintroduce global config

Closes #208

## Verification
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q -k 'scorecard_step_level_checkout_default_branch_guard or scorecard_global_env_when_publishing or scorecard_global_defaults_when_publishing'`
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q`
- `python3 scripts/checks/verify_supply_chain.py`
- `npm run check:supply-chain`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ossf-scorecard.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/ossf-scorecard.yml`
- `python3 -m py_compile scripts/checks/verify_supply_chain.py`
- `npm run check:github-bootstrap`
- `npm run check:security-gates`
- `./scripts/harness/quickcheck.sh`

## Security Notes
- Untrusted input: this change only affects repository-owned GitHub Actions YAML and the local supply-chain verifier; no runtime user files, URLs, subprocess inputs, IPC, WebView state, model downloads, or exports are introduced.
- Trust boundaries: OSSF Scorecard publishing remains constrained to pinned Actions and repository workflow policy; the Git default-branch guard is scoped to `actions/checkout` steps instead of workflow-global state.
- Allowlists / validation: the verifier now rejects top-level `env` or `defaults` whenever Scorecard publishing is present, while requiring each checkout step in that workflow to carry the narrow `GIT_CONFIG_* init.defaultBranch` guard.
- Safe failure: missing checkout guards or reintroduced global Scorecard workflow config fail the supply-chain check before merge.
- Logging / privacy: no new secrets, tokens, telemetry, or log output are added.
- Test points: regression tests cover the accepted step-level guard and rejected workflow-level `env` / `defaults`; quickcheck covers the full local harness.
