### PR TITLE
Redact YouTube downloader errors

### DIFF
--- a/services/analysis-engine/src/bandscope_analysis/youtube.py
+++ b/services/analysis-engine/src/bandscope_analysis/youtube.py
@@ -17,6 +17,10 @@ import yt_dlp  # type: ignore
 
 YOUTUBE_VIDEO_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{11}$")
 SUPPORTED_AUDIO_EXTENSIONS = (".opus", ".m4a", ".mp3", ".wav", ".aac", ".flac", ".ogg")
+YOUTUBE_DOWNLOAD_FAILED_MESSAGE = (
+    "Failed to download audio from YouTube. Please use a local audio file instead."
+)
+YOUTUBE_IMPORT_FAILED_MESSAGE = "YouTube import failed. Please use a local audio file instead."
 
 
 def validate_url(url: str) -> bool:
@@ -87,10 +91,7 @@ def _handle_download_error(e: yt_dlp.utils.DownloadError) -> Dict[str, Any]:
         "ok": False,
         "error": {
             "code": "download_failed",
-            "message": (
-                f"Failed to download audio from YouTube. "
-                f"Please use a local audio file instead. ({e})"
-            ),
+            "message": YOUTUBE_DOWNLOAD_FAILED_MESSAGE,
         },
     }
 
@@ -180,8 +181,11 @@ def download_youtube_audio(url: str, out_dir: str) -> Dict[str, Any]:
             }
     except yt_dlp.utils.DownloadError as e:
         return _handle_download_error(e)
-    except Exception as e:
-        return {"ok": False, "error": {"code": "download_error", "message": str(e)}}
+    except Exception:
+        return {
+            "ok": False,
+            "error": {"code": "download_error", "message": YOUTUBE_IMPORT_FAILED_MESSAGE},
+        }
 
 
 def main() -> None:

--- a/services/analysis-engine/tests/test_youtube.py
+++ b/services/analysis-engine/tests/test_youtube.py
@@ -201,7 +201,9 @@ def test_download_youtube_audio_info_none(mock_ydl_class: MagicMock) -> None:
 
     assert result["ok"] is False
     assert result["error"]["code"] == "download_error"
-    assert "Failed to extract info" in result["error"]["message"]
+    assert result["error"]["message"] == (
+        "YouTube import failed. Please use a local audio file instead."
+    )
 
 
 @patch("bandscope_analysis.youtube.yt_dlp.YoutubeDL")
@@ -225,25 +227,40 @@ def test_download_youtube_audio_generic_download_error(mock_ydl_class: MagicMock
     mock_ydl = MagicMock()
     mock_ydl_class.return_value.__enter__.return_value = mock_ydl
 
-    mock_ydl.extract_info.side_effect = yt_dlp.utils.DownloadError("Some random network error")
+    raw_error = (
+        "Some random network error for https://youtube.com/watch?v=abc123DEF45"
+        " with cookie=secret and /Users/test/local/path"
+    )
+    mock_ydl.extract_info.side_effect = yt_dlp.utils.DownloadError(raw_error)
 
     result = download_youtube_audio("https://youtube.com/watch?v=abc123DEF45", "/tmp")
 
     assert result["ok"] is False
     assert result["error"]["code"] == "download_failed"
-    assert "random network error" in result["error"]["message"]
+    assert result["error"]["message"] == (
+        "Failed to download audio from YouTube. Please use a local audio file instead."
+    )
+    assert raw_error not in result["error"]["message"]
+    assert "cookie=secret" not in result["error"]["message"]
+    assert "/Users/test/local/path" not in result["error"]["message"]
 
 
 @patch("bandscope_analysis.youtube.yt_dlp.YoutubeDL")
 def test_download_youtube_audio_exception(mock_ydl_class: MagicMock) -> None:
     """Test when an unexpected exception occurs."""
-    mock_ydl_class.side_effect = ValueError("Unexpected explosion")
+    raw_error = "Unexpected explosion with token=secret in /Users/test/private/path"
+    mock_ydl_class.side_effect = ValueError(raw_error)
 
     result = download_youtube_audio("https://youtube.com/watch?v=abc123DEF45", "/tmp")
 
     assert result["ok"] is False
     assert result["error"]["code"] == "download_error"
-    assert "Unexpected explosion" in result["error"]["message"]
+    assert result["error"]["message"] == (
+        "YouTube import failed. Please use a local audio file instead."
+    )
+    assert raw_error not in result["error"]["message"]
+    assert "token=secret" not in result["error"]["message"]
+    assert "/Users/test/private/path" not in result["error"]["message"]
 
 
 @patch("bandscope_analysis.youtube.yt_dlp.YoutubeDL")
@@ -368,4 +385,6 @@ def test_download_youtube_audio_second_info_none(mock_ydl_class: MagicMock) -> N
 
     assert result["ok"] is False
     assert result["error"]["code"] == "download_error"
-    assert "Failed to extract info" in result["error"]["message"]
+    assert result["error"]["message"] == (
+        "YouTube import failed. Please use a local audio file instead."
+    )


### PR DESCRIPTION
## Summary
- keep Python YouTube URL intake aligned with the existing strict allowlist while preserving the current validation coverage
- stop returning raw `yt-dlp` downloader exceptions in `download_failed` responses
- stop returning unexpected Python exception strings in `download_error` responses
- add regression tests for URL/path/token/cookie redaction across downloader and unexpected exception paths

Closes #205

## Verification
- `UV_FROZEN=1 uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_youtube.py -q -k 'generic_download_error or download_youtube_audio_exception'` (red before implementation)
- `UV_FROZEN=1 uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_youtube.py -q`
- `cd services/analysis-engine && UV_FROZEN=1 uv run pytest tests --cov=src/bandscope_analysis --cov-report=term-missing --cov-fail-under=100`
- `cd services/analysis-engine && UV_FROZEN=1 uv run ruff check src tests`
- `cd services/analysis-engine && UV_FROZEN=1 uv run ruff format --check src tests`
- `cd services/analysis-engine && UV_FROZEN=1 uv run mypy src`
- `npm run check:security-notes`
- `npm run check:security-gates`

## Security Notes
- Attack surface: YouTube URL intake, `yt-dlp` downloader errors, Python analysis-engine responses, and Tauri IPC propagation of Python error messages.
- Trust boundary: untrusted remote URL and downloader/subprocess failure text cross from `yt-dlp` into Python JSON, then through Tauri IPC to React.
- Mitigations: Python now returns fixed safe user-facing messages for generic downloader failures and unexpected exceptions instead of embedding raw exception text. Existing strict HTTPS host/path/query/video-id validation remains in place.
- Logging/privacy impact: raw URLs, cookies, tokens, local paths, and downloader internals are no longer included in these user-visible error responses.
- Safe failure: restricted content still maps to the existing safe local-file fallback message; unsupported URLs continue to fail before downloader invocation.
- Test points: regression tests assert cookie/token/path/URL fragments are not exposed, and full Python coverage plus security gates pass.
