### PR TITLE
feat: add metadata-only handoff export

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -377,6 +377,75 @@ describe("App", () => {
     });
   });
 
+  it("keeps handoff metadata tied to the source that produced the current result", async () => {
+    const originalCreateObjectUrl = URL.createObjectURL;
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    const createObjectUrl = vi.fn(() => "blob:handoff");
+    const revokeObjectUrl = vi.fn();
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectUrl
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectUrl
+    });
+
+    tauriInvoke
+      .mockResolvedValueOnce(bootstrapResponse())
+      .mockResolvedValueOnce(jobStatusResponse({
+        jobId: "job-1",
+        state: "queued",
+        progressLabel: "Queued for analysis"
+      }))
+      .mockResolvedValueOnce(succeededResult())
+      .mockResolvedValueOnce(
+        bootstrapResponse({
+          projectId: "project-2",
+          source: {
+            sourcePath: "/Users/test/Music/next-song.wav",
+            fileName: "next-song.wav",
+            fileSizeBytes: 2048000
+          }
+        })
+      );
+
+    try {
+      render(<App />);
+
+      fireEvent.click(screen.getByRole("button", { name: /choose local audio/i }));
+      await waitFor(() => expect(screen.getByText(/late-night-set\.wav/i)).toBeTruthy());
+
+      fireEvent.click(screen.getByRole("button", { name: /start analysis/i }));
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /Late Night Set/i })).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /choose local audio/i }));
+      await waitFor(() => expect(screen.getByText(/next-song\.wav/i)).toBeTruthy());
+
+      fireEvent.click(screen.getByRole("button", { name: /export handoff/i }));
+      const blob = createObjectUrl.mock.calls[0]?.[0] as Blob;
+      const payload = JSON.parse(await blob.text());
+
+      expect(payload.sourceAssets[0].fileName).toBe("late-night-set.wav");
+      expect(JSON.stringify(payload)).not.toContain("next-song.wav");
+      expect(click).toHaveBeenCalledTimes(1);
+      expect(revokeObjectUrl).toHaveBeenCalledWith("blob:handoff");
+    } finally {
+      click.mockRestore();
+      Object.defineProperty(URL, "createObjectURL", {
+        configurable: true,
+        value: originalCreateObjectUrl
+      });
+      Object.defineProperty(URL, "revokeObjectURL", {
+        configurable: true,
+        value: originalRevokeObjectUrl
+      });
+    }
+  });
+
   it("shows a safe failed status when the job poll returns an error", async () => {
     tauriInvoke
       .mockResolvedValueOnce(bootstrapResponse())

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -170,9 +170,11 @@ export function App() {
   const defaultRequest = useMemo(() => createDefaultAnalysisRequest(), []);
   const [jobStatus, setJobStatus] = useState<AnalysisJobStatus | null>(null);
   const [jobResult, setJobResult] = useState<RehearsalSong | null>(null);
+  const [jobResultBootstrap, setJobResultBootstrap] = useState<ProjectBootstrapSummary | null>(null);
   const [jobError, setJobError] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(false);
   const [selectedBootstrap, setSelectedBootstrap] = useState<ProjectBootstrapSummary | null>(null);
+  const [activeAnalysisBootstrap, setActiveAnalysisBootstrap] = useState<ProjectBootstrapSummary | null>(null);
   const [selectionError, setSelectionError] = useState<string | null>(null);
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [isImporting, setIsImporting] = useState(false);
@@ -198,9 +200,12 @@ export function App() {
         setJobStatus(nextStatus);
         if (nextStatus.state === "succeeded" && nextStatus.result) {
           setJobResult(nextStatus.result);
+          setJobResultBootstrap(activeAnalysisBootstrap);
+          setActiveAnalysisBootstrap(null);
           setJobError(null);
         }
         if (nextStatus.state === "failed") {
+          setActiveAnalysisBootstrap(null);
           setJobError(nextStatus.error?.message ?? t("analysisCouldNotStart"));
         }
       } catch (error) {
@@ -232,25 +237,32 @@ export function App() {
     }, ANALYSIS_POLL_INTERVAL_MS);
 
     return () => window.clearTimeout(timer);
-  }, [jobStatus, t]);
+  }, [activeAnalysisBootstrap, jobStatus, t]);
 
   /** Documented. */
   const handleStartAnalysis = async () => {
+    const submittedBootstrap = selectedBootstrap;
     setJobError(null);
     setJobResult(null);
+    setJobResultBootstrap(null);
     setJobStatus(null);
+    setActiveAnalysisBootstrap(submittedBootstrap);
     setIsStarting(true);
     try {
       const nextStatus = await startAnalysisJob(selectedRequest);
       setJobStatus(nextStatus);
       if (nextStatus.state === "succeeded" && nextStatus.result) {
         setJobResult(nextStatus.result);
+        setJobResultBootstrap(submittedBootstrap);
+        setActiveAnalysisBootstrap(null);
       }
       if (nextStatus.state === "failed") {
+        setActiveAnalysisBootstrap(null);
         setJobError(nextStatus.error?.message ?? t("analysisCouldNotStart"));
       }
     } catch {
       setJobStatus(null);
+      setActiveAnalysisBootstrap(null);
       setJobError(t("analysisCouldNotStart"));
     } finally {
       setIsStarting(false);
@@ -306,8 +318,10 @@ export function App() {
     try {
       const song = await loadProject();
       setJobResult(song);
+      setJobResultBootstrap(null);
       setJobError(null);
       setSelectedBootstrap(null);
+      setActiveAnalysisBootstrap(null);
       setJobStatus(null);
     } catch (e) {
       if (e instanceof Error && e.message !== "User cancelled") {
@@ -345,7 +359,7 @@ export function App() {
       return <LoadingState />;
     }
     if (jobResult) {
-      return <Workspace song={jobResult} sourceBootstrap={selectedBootstrap} onSongUpdate={handleSongUpdate} />;
+      return <Workspace song={jobResult} sourceBootstrap={jobResultBootstrap} onSongUpdate={handleSongUpdate} />;
     }
     return <EmptyState />;
   };

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -345,7 +345,7 @@ export function App() {
       return <LoadingState />;
     }
     if (jobResult) {
-      return <Workspace song={jobResult} onSongUpdate={handleSongUpdate} />;
+      return <Workspace song={jobResult} sourceBootstrap={selectedBootstrap} onSongUpdate={handleSongUpdate} />;
     }
     return <EmptyState />;
   };

--- a/apps/desktop/src/features/workspace/Workspace.test.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.test.tsx
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { createDemoRehearsalSong } from "@bandscope/shared-types";
-import { afterEach, describe, expect, it } from "vitest";
+import { createDemoRehearsalSong, type ProjectBootstrapSummary } from "@bandscope/shared-types";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Workspace } from "./Workspace";
 import { EmptyState, LoadingState } from "./WorkspaceStates";
 
 const originalLanguage = navigator.language;
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
 
 function setNavigatorLanguage(language: string) {
   Object.defineProperty(navigator, "language", {
@@ -16,6 +18,15 @@ function setNavigatorLanguage(language: string) {
 describe("Workspace", () => {
   afterEach(() => {
     setNavigatorLanguage(originalLanguage);
+    vi.restoreAllMocks();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: originalCreateObjectUrl
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: originalRevokeObjectUrl
+    });
   });
 
   it("keeps the song-structure grid valid when a project has no sections", () => {
@@ -78,6 +89,45 @@ describe("Workspace", () => {
     expect(screen.getByText("E2")).toBeTruthy();
     expect(screen.getByText("G2")).toBeTruthy();
     expect(screen.getByText(/2 notes mapped for rehearsal/i)).toBeTruthy();
+  });
+
+  it("exports a metadata-only handoff artifact from the workspace", async () => {
+    const song = createDemoRehearsalSong();
+    const sourceBootstrap: ProjectBootstrapSummary = {
+      projectId: "project-1",
+      sourceMode: "reference",
+      projectRoot: "/tmp/bandscope/projects/project-1",
+      cacheRoot: "/tmp/bandscope/cache/project-1",
+      tempRoot: "/tmp/bandscope/temp/project-1",
+      source: {
+        sourcePath: "/Users/test/Music/late-night-set.wav",
+        fileName: "late-night-set.wav",
+        extension: "wav",
+        fileSizeBytes: 1_024_000
+      }
+    };
+    const createObjectUrl = vi.fn(() => "blob:handoff");
+    const revokeObjectUrl = vi.fn();
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectUrl
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectUrl
+    });
+
+    render(<Workspace song={song} sourceBootstrap={sourceBootstrap} />);
+    fireEvent.click(screen.getByRole("button", { name: /export handoff/i }));
+
+    const blob = createObjectUrl.mock.calls[0]?.[0] as Blob;
+    const payload = JSON.parse(await blob.text());
+    expect(payload.artifactKind).toBe("bandscope.metadata-handoff");
+    expect(payload.sourceAssets[0].fileName).toBe("late-night-set.wav");
+    expect(JSON.stringify(payload)).not.toContain("/Users/test");
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:handoff");
   });
 
   it("localizes empty and loading state titles", () => {

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -1,16 +1,17 @@
 import { useState, useMemo, memo } from "react";
-import type { RehearsalSong } from "@bandscope/shared-types";
+import type { ProjectBootstrapSummary, RehearsalSong } from "@bandscope/shared-types";
 import { RoleSwitcher } from "./RoleSwitcher";
 import { SectionRoadmap } from "./SectionRoadmap";
 import { GrooveMap } from "./GrooveMap";
 import { createTranslator, detectPreferredLocale } from "../../i18n";
-import { generateCueSheetCsv, generateChartSummaryJson, sanitizeFilename } from "../../lib/export";
+import { generateCueSheetCsv, generateChartSummaryJson, generateMetadataHandoffJson, sanitizeFilename } from "../../lib/export";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardDescription } from "@/components/ui/card";
 import { Download } from "lucide-react";
 
 interface WorkspaceProps {
   song: RehearsalSong;
+  sourceBootstrap?: ProjectBootstrapSummary | null;
   onSongUpdate?: (song: RehearsalSong) => void;
 }
 
@@ -22,6 +23,19 @@ function formatTimelineTime(totalSeconds: number): string {
     .toString()
     .padStart(2, "0");
   return `${minutes}:${seconds}`;
+}
+
+/** Documented. */
+function downloadTextFile(contents: string, type: string, filename: string): void {
+  const blob = new Blob([contents], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 type Translator = ReturnType<typeof createTranslator>;
@@ -74,7 +88,7 @@ const SongStructure = memo(function SongStructure({ sections, t }: { sections: R
 });
 
 /** Documented. */
-export function Workspace({ song, onSongUpdate }: WorkspaceProps) {
+export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: WorkspaceProps) {
   const [activeRole, setActiveRole] = useState<string | null>(null);
   const t = useMemo(() => createTranslator(detectPreferredLocale()), []);
 
@@ -108,29 +122,23 @@ export function Workspace({ song, onSongUpdate }: WorkspaceProps) {
   /** Documented. */
   const handleExportCueSheet = () => {
     const csv = generateCueSheetCsv(song);
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${sanitizeFilename(song.title)}_cuesheet.csv`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadTextFile(csv, "text/csv;charset=utf-8;", `${sanitizeFilename(song.title)}_cuesheet.csv`);
   };
 
   /** Documented. */
   const handleExportChart = () => {
     const json = generateChartSummaryJson(song);
-    const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${sanitizeFilename(song.title)}_chart.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadTextFile(json, "application/json;charset=utf-8;", `${sanitizeFilename(song.title)}_chart.json`);
+  };
+
+  /** Documented. */
+  const handleExportHandoff = () => {
+    const json = generateMetadataHandoffJson(song, {
+      sourceBootstrap,
+      workspaceId: song.id,
+      workspaceTitle: song.title
+    });
+    downloadTextFile(json, "application/json;charset=utf-8;", `${sanitizeFilename(song.title)}_handoff.json`);
   };
 
   return (
@@ -163,6 +171,15 @@ export function Workspace({ song, onSongUpdate }: WorkspaceProps) {
             >
                 <Download className="mr-2 size-4 text-slate-300" />
               Export Chart (JSON)
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportHandoff}
+              className="min-h-10 border-teal-300/25 bg-teal-300/10 font-semibold text-teal-50 shadow-sm hover:bg-teal-300/20 hover:text-white"
+            >
+              <Download className="mr-2 size-4 text-teal-200" />
+              Export Handoff (JSON)
             </Button>
           </div>
           </div>

--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeFilename, escapeCsvField, generateCueSheetCsv, generateChartSummaryJson } from "./export";
-import type { RehearsalSong } from "@bandscope/shared-types";
+import {
+  sanitizeFilename,
+  escapeCsvField,
+  generateCueSheetCsv,
+  generateChartSummaryJson,
+  generateMetadataHandoffJson,
+  createReanalysisRequestFromHandoff
+} from "./export";
+import type { ProjectBootstrapSummary, RehearsalSong } from "@bandscope/shared-types";
 
 describe("export sanitization", () => {
   it("sanitizes filename correctly", () => {
@@ -134,5 +141,92 @@ describe("export generation", () => {
     const jsonStr = generateChartSummaryJson(mockSongNoHeadline);
     const parsed = JSON.parse(jsonStr);
     expect(parsed.headline).toBe("");
+  });
+
+  it("generates a metadata-only local handoff without source paths or transcription data", () => {
+    const sourceBootstrap: ProjectBootstrapSummary = {
+      projectId: "project-1",
+      sourceMode: "reference",
+      projectRoot: "/tmp/bandscope/projects/project-1",
+      cacheRoot: "/tmp/bandscope/cache/project-1",
+      tempRoot: "/tmp/bandscope/temp/project-1",
+      source: {
+        sourcePath: "/Users/test/Music/late-night-set.wav",
+        fileName: "late-night-set.wav",
+        extension: "wav",
+        fileSizeBytes: 1_024_000
+      }
+    };
+    const songWithTranscription: RehearsalSong = {
+      ...mockSong,
+      sections: [{
+        ...mockSong.sections[0]!,
+        roles: [{
+          ...mockSong.sections[0]!.roles[0]!,
+          transcription: [{ pitch: "E2", onset: 0, offset: 1, velocity: 0.7 }]
+        }]
+      }]
+    };
+
+    const json = generateMetadataHandoffJson(songWithTranscription, {
+      createdAt: "2026-06-15T08:30:00.000Z",
+      sourceBootstrap,
+      workspaceId: "workspace-1",
+      workspaceTitle: "Friday rehearsal"
+    });
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toMatchObject({
+      artifactKind: "bandscope.metadata-handoff",
+      artifactVersion: 1,
+      workspace: { id: "workspace-1", title: "Friday rehearsal", workspaceVersion: 1 },
+      song: { id: "test", title: "Test" },
+      sourceAssets: [{
+        referenceKind: "local_audio",
+        sourceMode: "reference",
+        fileName: "late-night-set.wav",
+        extension: "wav",
+        fileSizeBytes: 1_024_000,
+        status: "referenced"
+      }]
+    });
+    expect(json).not.toContain("/Users/test");
+    expect(json).not.toContain("sourcePath");
+    expect(json).not.toContain("transcription");
+    expect(parsed.sections[0].roleBuckets[0]).toEqual({
+      id: "r1",
+      name: "Bass",
+      roleType: "instrument",
+      confidence: { level: "high", source: "model", notes: "" },
+      rehearsalPriority: "high"
+    });
+  });
+
+  it("creates a local re-analysis request from a received handoff and selected replacement asset", () => {
+    const handoff = JSON.parse(generateMetadataHandoffJson(mockSong, {
+      createdAt: "2026-06-15T08:30:00.000Z",
+      workspaceId: "workspace-1",
+      workspaceTitle: "Friday rehearsal"
+    }));
+    const selectedSource: ProjectBootstrapSummary = {
+      projectId: "recipient-project",
+      sourceMode: "reference",
+      projectRoot: "/tmp/bandscope/projects/recipient-project",
+      cacheRoot: "/tmp/bandscope/cache/recipient-project",
+      tempRoot: "/tmp/bandscope/temp/recipient-project",
+      source: {
+        sourcePath: "/Users/recipient/Music/late-night-set.wav",
+        fileName: "late-night-set.wav",
+        extension: "wav",
+        fileSizeBytes: 1_024_000
+      }
+    };
+
+    expect(createReanalysisRequestFromHandoff(handoff, selectedSource)).toEqual({
+      sourceKind: "local_audio",
+      projectId: "recipient-project",
+      sourceLabel: "late-night-set.wav",
+      roleFocus: ["r1"]
+    });
   });
 });

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -1,4 +1,13 @@
-import type { RehearsalSong } from "@bandscope/shared-types";
+import {
+  parseAnalysisJobRequest,
+  parseMetadataHandoffArtifact,
+  parseProjectBootstrapSummary,
+  parseRehearsalSong,
+  type AnalysisJobRequest,
+  type MetadataHandoffArtifact,
+  type ProjectBootstrapSummary,
+  type RehearsalSong
+} from "@bandscope/shared-types";
 
 // Security notes:
 // 1. Filename sanitization to prevent directory traversal or invalid characters.
@@ -68,4 +77,88 @@ export function generateChartSummaryJson(song: RehearsalSong): string {
     }))
   };
   return JSON.stringify(summary, null, 2);
+}
+
+/** Documented. */
+export function createMetadataHandoffArtifact(
+  song: RehearsalSong,
+  options: {
+    createdAt?: string;
+    sourceBootstrap?: ProjectBootstrapSummary | null;
+    workspaceId?: string;
+    workspaceTitle?: string;
+  } = {}
+): MetadataHandoffArtifact {
+  const parsedSong = parseRehearsalSong(song);
+  const sourceBootstrap = options.sourceBootstrap
+    ? parseProjectBootstrapSummary(options.sourceBootstrap)
+    : null;
+
+  return parseMetadataHandoffArtifact({
+    artifactKind: "bandscope.metadata-handoff",
+    artifactVersion: 1,
+    createdAt: options.createdAt ?? new Date().toISOString(),
+    workspace: {
+      id: options.workspaceId ?? parsedSong.id,
+      title: options.workspaceTitle ?? parsedSong.title,
+      workspaceVersion: 1
+    },
+    song: {
+      id: parsedSong.id,
+      title: parsedSong.title,
+      exportSummary: parsedSong.exportSummary
+    },
+    sections: parsedSong.sections.map((section) => ({
+      id: section.id,
+      label: section.label,
+      timeRange: section.timeRange,
+      confidence: section.confidence,
+      roleBuckets: section.roles.map((role) => ({
+        id: role.id,
+        name: role.name,
+        roleType: role.roleType,
+        confidence: role.confidence,
+        rehearsalPriority: role.rehearsalPriority
+      }))
+    })),
+    sourceAssets: sourceBootstrap
+      ? [
+          {
+            referenceKind: "local_audio",
+            sourceMode: "reference",
+            fileName: sourceBootstrap.source.fileName,
+            extension: sourceBootstrap.source.extension,
+            fileSizeBytes: sourceBootstrap.source.fileSizeBytes,
+            status: "referenced"
+          }
+        ]
+      : []
+  });
+}
+
+/** Documented. */
+export function generateMetadataHandoffJson(
+  song: RehearsalSong,
+  options: Parameters<typeof createMetadataHandoffArtifact>[1] = {}
+): string {
+  return JSON.stringify(createMetadataHandoffArtifact(song, options), null, 2);
+}
+
+/** Documented. */
+export function createReanalysisRequestFromHandoff(
+  handoff: unknown,
+  selectedSource: ProjectBootstrapSummary
+): AnalysisJobRequest {
+  const parsedHandoff = parseMetadataHandoffArtifact(handoff);
+  const parsedSource = parseProjectBootstrapSummary(selectedSource);
+  const roleFocus = Array.from(
+    new Set(parsedHandoff.sections.flatMap((section) => section.roleBuckets.map((role) => role.id)))
+  );
+
+  return parseAnalysisJobRequest({
+    sourceKind: "local_audio",
+    projectId: parsedSource.projectId,
+    sourceLabel: parsedSource.source.fileName,
+    roleFocus
+  });
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -198,6 +198,53 @@ export type ProjectBootstrapSummary = {
 };
 
 /** Documented. */
+export type MetadataHandoffSourceAsset = {
+  referenceKind: "local_audio";
+  sourceMode: "reference";
+  fileName: string;
+  extension: (typeof SUPPORTED_AUDIO_FORMATS)[number];
+  fileSizeBytes: number;
+  status: "referenced" | "missing";
+};
+
+/** Documented. */
+export type MetadataHandoffRoleBucket = {
+  id: string;
+  name: string;
+  roleType: RehearsalRole["roleType"];
+  confidence: ConfidenceMarker;
+  rehearsalPriority: RehearsalPriority;
+};
+
+/** Documented. */
+export type MetadataHandoffSection = {
+  id: string;
+  label: SectionFormLabel;
+  timeRange: SectionTimeRange;
+  confidence: ConfidenceMarker;
+  roleBuckets: MetadataHandoffRoleBucket[];
+};
+
+/** Documented. */
+export type MetadataHandoffArtifact = {
+  artifactKind: "bandscope.metadata-handoff";
+  artifactVersion: 1;
+  createdAt: string;
+  workspace: {
+    id: string;
+    title: string;
+    workspaceVersion: number;
+  };
+  song: {
+    id: string;
+    title: string;
+    exportSummary: ExportSummary;
+  };
+  sections: MetadataHandoffSection[];
+  sourceAssets: MetadataHandoffSourceAsset[];
+};
+
+/** Documented. */
 export type AnalysisJobRequest =
   | {
       sourceKind: "demo";
@@ -249,6 +296,7 @@ const ANALYSIS_SOURCE_KINDS = ["demo", "local_audio"] as const;
 const ANALYSIS_JOB_STATES = ["queued", "running", "succeeded", "failed"] as const;
 const ANALYSIS_JOB_ERROR_CODES = ["invalid_request", "not_found", "engine_unavailable"] as const;
 const PACK_STATES = ["queued", "analyzing", "ready", "failed"] as const;
+const HANDOFF_ASSET_STATUSES = ["referenced", "missing"] as const;
 
 type ValidationOptions = {
   acceptLegacySectionTimeRanges: boolean;
@@ -513,6 +561,198 @@ export function parseProjectBootstrapSummary(value: unknown): ProjectBootstrapSu
   }
 
   return structuredClone(value as ProjectBootstrapSummary);
+}
+
+/** Documented. */
+function validateMetadataHandoffSourceAsset(value: unknown, path: string): string | null {
+  if (!isRecord(value)) {
+    return invalidField(path);
+  }
+  const extraKey = unexpectedKey(value, ["referenceKind", "sourceMode", "fileName", "extension", "fileSizeBytes", "status"], path);
+  if (extraKey) {
+    return extraKey;
+  }
+  if (value.referenceKind !== "local_audio") {
+    return invalidField(`${path}.referenceKind`);
+  }
+  if (value.sourceMode !== "reference") {
+    return invalidField(`${path}.sourceMode`);
+  }
+  if (typeof value.fileName !== "string" || value.fileName.trim().length === 0) {
+    return invalidField(`${path}.fileName`);
+  }
+  if (!isOneOf(SUPPORTED_AUDIO_FORMATS, value.extension)) {
+    return invalidField(`${path}.extension`);
+  }
+  if (typeof value.fileSizeBytes !== "number" || !Number.isFinite(value.fileSizeBytes) || value.fileSizeBytes <= 0) {
+    return invalidField(`${path}.fileSizeBytes`);
+  }
+  if (!isOneOf(HANDOFF_ASSET_STATUSES, value.status)) {
+    return invalidField(`${path}.status`);
+  }
+
+  return null;
+}
+
+/** Documented. */
+function validateMetadataHandoffRoleBucket(value: unknown, path: string): string | null {
+  if (!isRecord(value)) {
+    return invalidField(path);
+  }
+  const extraKey = unexpectedKey(value, ["id", "name", "roleType", "confidence", "rehearsalPriority"], path);
+  if (extraKey) {
+    return extraKey;
+  }
+  if (typeof value.id !== "string") {
+    return invalidField(`${path}.id`);
+  }
+  if (typeof value.name !== "string") {
+    return invalidField(`${path}.name`);
+  }
+  if (!isOneOf(ROLE_TYPES, value.roleType)) {
+    return invalidField(`${path}.roleType`);
+  }
+  const confidenceError = validateConfidenceMarker(value.confidence, `${path}.confidence`);
+  if (confidenceError) {
+    return confidenceError;
+  }
+  if (!isOneOf(REHEARSAL_PRIORITIES, value.rehearsalPriority)) {
+    return invalidField(`${path}.rehearsalPriority`);
+  }
+
+  return null;
+}
+
+/** Documented. */
+function validateMetadataHandoffSection(value: unknown, path: string): string | null {
+  if (!isRecord(value)) {
+    return invalidField(path);
+  }
+  const extraKey = unexpectedKey(value, ["id", "label", "timeRange", "confidence", "roleBuckets"], path);
+  if (extraKey) {
+    return extraKey;
+  }
+  if (typeof value.id !== "string") {
+    return invalidField(`${path}.id`);
+  }
+  if (!isOneOf(SECTION_FORM_LABELS, value.label)) {
+    return invalidField(`${path}.label`);
+  }
+  const timeRangeError = validateSectionTimeRange(value.timeRange, `${path}.timeRange`);
+  if (timeRangeError) {
+    return timeRangeError;
+  }
+  const confidenceError = validateConfidenceMarker(value.confidence, `${path}.confidence`);
+  if (confidenceError) {
+    return confidenceError;
+  }
+  if (!isDenseArray(value.roleBuckets)) {
+    return invalidField(`${path}.roleBuckets`);
+  }
+  for (const [index, role] of value.roleBuckets.entries()) {
+    const roleError = validateMetadataHandoffRoleBucket(role, `${path}.roleBuckets[${index}]`);
+    if (roleError) {
+      return roleError;
+    }
+  }
+
+  return null;
+}
+
+/** Documented. */
+function validateMetadataHandoffArtifact(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return invalidField("root");
+  }
+  const extraKey = unexpectedKey(
+    value,
+    ["artifactKind", "artifactVersion", "createdAt", "workspace", "song", "sections", "sourceAssets"],
+    ""
+  );
+  if (extraKey) {
+    return extraKey;
+  }
+  if (value.artifactKind !== "bandscope.metadata-handoff") {
+    return invalidField("artifactKind");
+  }
+  if (value.artifactVersion !== 1) {
+    return invalidField("artifactVersion");
+  }
+  if (typeof value.createdAt !== "string" || value.createdAt.trim().length === 0) {
+    return invalidField("createdAt");
+  }
+  if (!isRecord(value.workspace)) {
+    return invalidField("workspace");
+  }
+  const workspaceExtraKey = unexpectedKey(value.workspace, ["id", "title", "workspaceVersion"], "workspace");
+  if (workspaceExtraKey) {
+    return workspaceExtraKey;
+  }
+  if (typeof value.workspace.id !== "string") {
+    return invalidField("workspace.id");
+  }
+  if (typeof value.workspace.title !== "string") {
+    return invalidField("workspace.title");
+  }
+  if (
+    typeof value.workspace.workspaceVersion !== "number" ||
+    !Number.isInteger(value.workspace.workspaceVersion) ||
+    value.workspace.workspaceVersion < 1
+  ) {
+    return invalidField("workspace.workspaceVersion");
+  }
+  if (!isRecord(value.song)) {
+    return invalidField("song");
+  }
+  const songExtraKey = unexpectedKey(value.song, ["id", "title", "exportSummary"], "song");
+  if (songExtraKey) {
+    return songExtraKey;
+  }
+  if (typeof value.song.id !== "string") {
+    return invalidField("song.id");
+  }
+  if (typeof value.song.title !== "string") {
+    return invalidField("song.title");
+  }
+  const exportSummaryError = validateExportSummary(value.song.exportSummary, "song.exportSummary");
+  if (exportSummaryError) {
+    return exportSummaryError;
+  }
+  if (!isDenseArray(value.sections)) {
+    return invalidField("sections");
+  }
+  for (const [index, section] of value.sections.entries()) {
+    const sectionError = validateMetadataHandoffSection(section, `sections[${index}]`);
+    if (sectionError) {
+      return sectionError;
+    }
+  }
+  if (!isDenseArray(value.sourceAssets)) {
+    return invalidField("sourceAssets");
+  }
+  for (const [index, sourceAsset] of value.sourceAssets.entries()) {
+    const sourceAssetError = validateMetadataHandoffSourceAsset(sourceAsset, `sourceAssets[${index}]`);
+    if (sourceAssetError) {
+      return sourceAssetError;
+    }
+  }
+
+  return null;
+}
+
+/** Documented. */
+export function isMetadataHandoffArtifact(value: unknown): value is MetadataHandoffArtifact {
+  return validateMetadataHandoffArtifact(value) === null;
+}
+
+/** Documented. */
+export function parseMetadataHandoffArtifact(value: unknown): MetadataHandoffArtifact {
+  const validationError = validateMetadataHandoffArtifact(value);
+  if (validationError) {
+    throw new Error(validationError);
+  }
+
+  return structuredClone(value as MetadataHandoffArtifact);
 }
 
 /** Documented. */

--- a/packages/shared-types/test/index.test.ts
+++ b/packages/shared-types/test/index.test.ts
@@ -8,11 +8,14 @@ import {
   isAnalysisJobStatus,
   parseAnalysisJobStatus,
   parseLocalAudioSource,
+  parseMetadataHandoffArtifact,
   parseProjectBootstrapSummary,
   parseRehearsalSong,
+  isMetadataHandoffArtifact,
   isRehearsalWorkspace,
   parseRehearsalWorkspace,
   parseSongRehearsalPack,
+  type MetadataHandoffArtifact,
   SongRehearsalPack,
   RehearsalWorkspace,
   parseAnalysisJobRequest,
@@ -390,6 +393,113 @@ describe("shared type helpers", () => {
       tempRoot: "/tmp/bandscope/temp/project-1",
       source: { ...source, extension: "ogg" }
     })).toThrow("project bootstrap summary.source");
+  });
+
+  it("validates metadata-only handoff artifacts without bundled assets or paths", () => {
+    const artifact: MetadataHandoffArtifact = {
+      artifactKind: "bandscope.metadata-handoff",
+      artifactVersion: 1,
+      createdAt: "2026-06-15T08:30:00.000Z",
+      workspace: {
+        id: "workspace-1",
+        title: "Friday rehearsal",
+        workspaceVersion: 1
+      },
+      song: {
+        id: "demo-song",
+        title: "Late Night Set",
+        exportSummary: createDemoRehearsalSong().exportSummary
+      },
+      sections: [
+        {
+          id: "verse-1",
+          label: "verse",
+          timeRange: { start: 10, end: 30 },
+          confidence: createDemoRehearsalSong().sections[0]!.confidence,
+          roleBuckets: [
+            {
+              id: "bass-guitar",
+              name: "Bass Guitar",
+              roleType: "instrument",
+              confidence: createDemoRehearsalSong().sections[0]!.roles[0]!.confidence,
+              rehearsalPriority: "high"
+            }
+          ]
+        }
+      ],
+      sourceAssets: [
+        {
+          referenceKind: "local_audio",
+          sourceMode: "reference",
+          fileName: "late-night-set.wav",
+          extension: "wav",
+          fileSizeBytes: 1_024_000,
+          status: "referenced"
+        }
+      ]
+    };
+
+    expect(isMetadataHandoffArtifact(artifact)).toBe(true);
+    expect(parseMetadataHandoffArtifact(artifact)).toEqual(artifact);
+    expect(() => parseMetadataHandoffArtifact({
+      ...artifact,
+      artifactVersion: 2
+    })).toThrow("artifactVersion");
+    expect(() => parseMetadataHandoffArtifact({
+      ...artifact,
+      sourceAssets: [{ ...artifact.sourceAssets[0], sourcePath: "/Users/test/Music/late-night-set.wav" }]
+    })).toThrow("sourceAssets[0].sourcePath");
+    expect(() => parseMetadataHandoffArtifact({
+      ...artifact,
+      sections: [{
+        ...artifact.sections[0],
+        roleBuckets: [{ ...artifact.sections[0]!.roleBuckets[0], confidence: { level: "sure" } }]
+      }]
+    })).toThrow("sections[0].roleBuckets[0].confidence");
+
+    const invalidCases: Array<{ message: string; payload: unknown }> = [
+      { message: "root", payload: null },
+      { message: "extraField", payload: { ...artifact, extraField: true } },
+      { message: "artifactKind", payload: { ...artifact, artifactKind: "other" } },
+      { message: "createdAt", payload: { ...artifact, createdAt: "   " } },
+      { message: "workspace", payload: { ...artifact, workspace: null } },
+      { message: "workspace.extraField", payload: { ...artifact, workspace: { ...artifact.workspace, extraField: true } } },
+      { message: "workspace.id", payload: { ...artifact, workspace: { ...artifact.workspace, id: 3 } } },
+      { message: "workspace.title", payload: { ...artifact, workspace: { ...artifact.workspace, title: 3 } } },
+      { message: "workspace.workspaceVersion", payload: { ...artifact, workspace: { ...artifact.workspace, workspaceVersion: 0 } } },
+      { message: "song", payload: { ...artifact, song: null } },
+      { message: "song.extraField", payload: { ...artifact, song: { ...artifact.song, extraField: true } } },
+      { message: "song.id", payload: { ...artifact, song: { ...artifact.song, id: 3 } } },
+      { message: "song.title", payload: { ...artifact, song: { ...artifact.song, title: 3 } } },
+      {
+        message: "song.exportSummary.format",
+        payload: { ...artifact, song: { ...artifact.song, exportSummary: { ...artifact.song.exportSummary, format: "pdf" } } }
+      },
+      { message: "sections", payload: { ...artifact, sections: "not-an-array" } },
+      { message: "sections[0]", payload: { ...artifact, sections: [null] } },
+      { message: "sections[0].id", payload: { ...artifact, sections: [{ ...artifact.sections[0], id: 3 }] } },
+      { message: "sections[0].label", payload: { ...artifact, sections: [{ ...artifact.sections[0], label: "solo" }] } },
+      { message: "sections[0].timeRange.start", payload: { ...artifact, sections: [{ ...artifact.sections[0], timeRange: { start: -1, end: 30 } }] } },
+      { message: "sections[0].confidence.source", payload: { ...artifact, sections: [{ ...artifact.sections[0], confidence: { ...artifact.sections[0]!.confidence, source: "other" } }] } },
+      { message: "sections[0].roleBuckets", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: "not-an-array" }] } },
+      { message: "sections[0].roleBuckets[0]", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: [null] }] } },
+      { message: "sections[0].roleBuckets[0].id", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: [{ ...artifact.sections[0]!.roleBuckets[0], id: 3 }] }] } },
+      { message: "sections[0].roleBuckets[0].name", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: [{ ...artifact.sections[0]!.roleBuckets[0], name: 3 }] }] } },
+      { message: "sections[0].roleBuckets[0].roleType", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: [{ ...artifact.sections[0]!.roleBuckets[0], roleType: "drums" }] }] } },
+      { message: "sections[0].roleBuckets[0].rehearsalPriority", payload: { ...artifact, sections: [{ ...artifact.sections[0], roleBuckets: [{ ...artifact.sections[0]!.roleBuckets[0], rehearsalPriority: "urgent" }] }] } },
+      { message: "sourceAssets", payload: { ...artifact, sourceAssets: "not-an-array" } },
+      { message: "sourceAssets[0]", payload: { ...artifact, sourceAssets: [null] } },
+      { message: "sourceAssets[0].referenceKind", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], referenceKind: "stem" }] } },
+      { message: "sourceAssets[0].sourceMode", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], sourceMode: "copy" }] } },
+      { message: "sourceAssets[0].fileName", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], fileName: "   " }] } },
+      { message: "sourceAssets[0].extension", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], extension: "ogg" }] } },
+      { message: "sourceAssets[0].fileSizeBytes", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], fileSizeBytes: 0 }] } },
+      { message: "sourceAssets[0].status", payload: { ...artifact, sourceAssets: [{ ...artifact.sourceAssets[0], status: "bundled" }] } }
+    ];
+
+    for (const testCase of invalidCases) {
+      expect(() => parseMetadataHandoffArtifact(testCase.payload)).toThrow(testCase.message);
+    }
   });
 
   it("creates a rehearsal song with section and role level guidance", () => {


### PR DESCRIPTION
## Summary
- Add a metadata-only BandScope handoff artifact contract with runtime validation and parser coverage.
- Export handoff JSON from the workspace without source paths, transcription data, stems, or audio bytes.
- Add recipient-side reanalysis request creation from a selected local source asset.

## Verification
- ./scripts/harness/quickcheck.sh

## Security Notes
- Handoff files are treated as untrusted project/export data and must pass the shared runtime parser before reuse.
- The exported artifact deliberately excludes absolute source paths, cache roots, temp roots, transcription payloads, stems, and audio bytes; it only carries file metadata, section summaries, role buckets, and confidence values.
- Reanalysis requires the recipient to select a local source asset, keeping local file access explicit and avoiding remote/network runtime paths.
- Tests assert path redaction and schema rejection for leaked sourcePath fields.

Closes #150