### PR TITLE
feat: stream staged analysis progress

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -5,11 +5,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 use std::{
     collections::HashMap,
-    io::{Read, Write},
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
+        mpsc,
         Arc, Mutex,
     },
     thread,
@@ -54,6 +55,8 @@ struct AnalysisJobRequest {
     source_label: String,
     role_focus: Vec<String>,
     local_source: Option<LocalAudioSourcePayload>,
+    cache_root: Option<String>,
+    temp_root: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -78,6 +81,26 @@ enum AnalysisJobState {
     Running,
     Succeeded,
     Failed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AnalysisJobStage {
+    Queued,
+    Decode,
+    Separate,
+    Analyze,
+    Persist,
+    Ready,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AnalysisCacheStatus {
+    Disabled,
+    Miss,
+    Hit,
+    Stored,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -215,6 +238,12 @@ struct AnalysisJobStatus {
     updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     progress_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    progress_stage: Option<AnalysisJobStage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    progress_percent: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_status: Option<AnalysisCacheStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<RehearsalSongPayload>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -545,6 +574,8 @@ fn parse_request_payload(payload: Value) -> Result<AnalysisJobRequest, String> {
         source_label: source_label.to_string(),
         role_focus: parsed_role_focus,
         local_source,
+        cache_root: None,
+        temp_root: None,
     })
 }
 
@@ -560,6 +591,9 @@ fn failed_status(
         requested_at,
         updated_at: iso_timestamp_now(),
         progress_label: None,
+        progress_stage: None,
+        progress_percent: None,
+        cache_status: None,
         result: None,
         error: Some(AnalysisJobError {
             code,
@@ -593,12 +627,24 @@ fn lookup_bootstrap_source(
         .ok_or_else(|| "Analysis job source was not found. Choose local audio again.".to_string())
 }
 
+fn drain_analysis_status_updates(
+    state: &AppState,
+    status_rx: &mpsc::Receiver<AnalysisJobStatus>,
+    last_status: &mut Option<AnalysisJobStatus>,
+) {
+    while let Ok(status) = status_rx.try_recv() {
+        store_status(state, status.clone());
+        *last_status = Some(status);
+    }
+}
+
 fn run_analysis_engine(
+    state: AppState,
     job_id: String,
     request: AnalysisJobRequest,
     requested_at: String,
 ) -> AnalysisJobStatus {
-    let (working_dir, program, args) = analysis_command();
+    let (working_dir, program, mut args) = analysis_command();
 
     if program == MISSING_ANALYSIS_PYTHON {
         return failed_status(
@@ -608,6 +654,7 @@ fn run_analysis_engine(
             "Analysis engine is unavailable.",
         );
     }
+    args.push("--progress-jsonl".into());
 
     let mut process = match Command::new(program)
         .args(args)
@@ -629,13 +676,63 @@ fn run_analysis_engine(
     };
 
     let payload = json!({
-        "jobId": job_id,
+        "jobId": job_id.clone(),
         "request": request,
+    });
+    let Some(stdout) = process.stdout.take() else {
+        let _ = process.kill();
+        let _ = process.wait();
+        return failed_status(
+            job_id,
+            requested_at,
+            AnalysisJobErrorCode::EngineUnavailable,
+            "Analysis engine is unavailable.",
+        );
+    };
+    let Some(stderr) = process.stderr.take() else {
+        let _ = process.kill();
+        let _ = process.wait();
+        return failed_status(
+            job_id,
+            requested_at,
+            AnalysisJobErrorCode::EngineUnavailable,
+            "Analysis engine is unavailable.",
+        );
+    };
+    let (status_tx, status_rx) = mpsc::channel::<AnalysisJobStatus>();
+    let stdout_reader = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let mut last_status = None;
+        for line in reader.lines() {
+            let Ok(line) = line else {
+                break;
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Ok(status) = serde_json::from_str::<AnalysisJobStatus>(trimmed) {
+                last_status = Some(status.clone());
+                if status_tx.send(status).is_err() {
+                    break;
+                }
+            }
+        }
+        last_status
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut reader = stderr;
+        let mut buffer = Vec::new();
+        let _ = reader.read_to_end(&mut buffer);
+        buffer
     });
 
     if let Some(mut stdin) = process.stdin.take() {
         if stdin.write_all(payload.to_string().as_bytes()).is_err() {
             let _ = process.kill();
+            let _ = process.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
             return failed_status(
                 payload["jobId"]
                     .as_str()
@@ -649,13 +746,21 @@ fn run_analysis_engine(
     }
 
     let deadline = Instant::now() + ANALYSIS_PROCESS_TIMEOUT;
+    let mut last_status = None;
+    let exit_status;
     loop {
+        drain_analysis_status_updates(&state, &status_rx, &mut last_status);
         match process.try_wait() {
-            Ok(Some(_)) => break,
+            Ok(Some(status)) => {
+                exit_status = status;
+                break;
+            }
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = process.kill();
                     let _ = process.wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
                     return failed_status(
                         payload["jobId"]
                             .as_str()
@@ -671,6 +776,8 @@ fn run_analysis_engine(
             Err(_) => {
                 let _ = process.kill();
                 let _ = process.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
                 return failed_status(
                     payload["jobId"]
                         .as_str()
@@ -683,23 +790,14 @@ fn run_analysis_engine(
             }
         }
     }
+    let reader_last_status = stdout_reader.join().unwrap_or(None);
+    let _ = stderr_reader.join();
+    drain_analysis_status_updates(&state, &status_rx, &mut last_status);
+    if last_status.is_none() {
+        last_status = reader_last_status;
+    }
 
-    let output = match process.wait_with_output() {
-        Ok(output) => output,
-        Err(_) => {
-            return failed_status(
-                payload["jobId"]
-                    .as_str()
-                    .unwrap_or("unknown-job")
-                    .to_string(),
-                requested_at,
-                AnalysisJobErrorCode::EngineUnavailable,
-                "Analysis engine is unavailable.",
-            )
-        }
-    };
-
-    if !output.status.success() {
+    if !exit_status.success() {
         return failed_status(
             payload["jobId"]
                 .as_str()
@@ -711,7 +809,7 @@ fn run_analysis_engine(
         );
     }
 
-    serde_json::from_slice::<AnalysisJobStatus>(&output.stdout).unwrap_or_else(|_| {
+    last_status.unwrap_or_else(|| {
         failed_status(
             payload["jobId"]
                 .as_str()
@@ -760,6 +858,8 @@ fn start_analysis_job(request: Value, state: tauri::State<'_, AppState>) -> Anal
             }
         };
         parsed_request.source_label = bootstrap.source.file_name.clone();
+        parsed_request.cache_root = Some(bootstrap.cache_root.clone());
+        parsed_request.temp_root = Some(bootstrap.temp_root.clone());
         parsed_request.local_source = Some(bootstrap.source);
     }
 
@@ -778,6 +878,9 @@ fn start_analysis_job(request: Value, state: tauri::State<'_, AppState>) -> Anal
         requested_at: requested_at.clone(),
         updated_at: requested_at.clone(),
         progress_label: Some("Queued for analysis".into()),
+        progress_stage: Some(AnalysisJobStage::Queued),
+        progress_percent: Some(0),
+        cache_status: Some(AnalysisCacheStatus::Disabled),
         result: None,
         error: None,
     };
@@ -793,11 +896,14 @@ fn start_analysis_job(request: Value, state: tauri::State<'_, AppState>) -> Anal
                 requested_at: requested_at.clone(),
                 updated_at: iso_timestamp_now(),
                 progress_label: Some("Running analysis".into()),
+                progress_stage: Some(AnalysisJobStage::Decode),
+                progress_percent: Some(10),
+                cache_status: None,
                 result: None,
                 error: None,
             },
         );
-        let finished = run_analysis_engine(job_id, parsed_request, requested_at);
+        let finished = run_analysis_engine(app_state.clone(), job_id, parsed_request, requested_at);
         store_status(&app_state, finished);
         release_job_slot(&app_state);
     });

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -377,6 +377,36 @@ describe("App", () => {
     });
   });
 
+  it("shows the engine stage label and accessible progress value while analysis runs", async () => {
+    tauriInvoke
+      .mockResolvedValueOnce(bootstrapResponse())
+      .mockResolvedValueOnce(jobStatusResponse({
+        jobId: "job-progress-1",
+        state: "running",
+        progressLabel: "Separating stems... (45%)",
+        progressStage: "separate",
+        progressPercent: 45,
+        cacheStatus: "miss"
+      }));
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /choose local audio/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/late-night-set\.wav/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /start analysis/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/separating stems/i)).toBeTruthy();
+    });
+    expect(screen.getByRole("progressbar", { name: /analysis progress/i })).toHaveAttribute(
+      "aria-valuenow",
+      "45"
+    );
+  });
+
   it("keeps handoff metadata tied to the source that produced the current result", async () => {
     const originalCreateObjectUrl = URL.createObjectURL;
     const originalRevokeObjectUrl = URL.revokeObjectURL;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -44,6 +44,7 @@ import { Workspace } from "./features/workspace/Workspace";
 import { EmptyState, ErrorState, LoadingState } from "./features/workspace/WorkspaceStates";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 
 const ANALYSIS_POLL_INTERVAL_MS = 250;
 
@@ -64,9 +65,13 @@ const BRAND_BAR_HEIGHTS = ["h-3", "h-5", "h-7", "h-4", "h-6"] as const;
 /** Documented. */
 function progressMessage(
   t: ReturnType<typeof createTranslator>,
-  state: AnalysisJobStatus["state"]
+  status: AnalysisJobStatus
 ): string {
-  switch (state) {
+  if (status.progressLabel?.trim()) {
+    return status.progressLabel;
+  }
+
+  switch (status.state) {
     case "queued":
       return t("analysisStateQueued");
     case "running":
@@ -571,13 +576,25 @@ export function App() {
 
                 {jobStatus && (
                   <div
-                    className="inline-flex items-center rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 font-semibold text-cyan-100"
+                    className="min-w-52 rounded-xl border border-cyan-300/20 bg-cyan-300/10 px-3 py-2 font-semibold text-cyan-100"
                     role="status"
                     aria-live="polite"
                     aria-atomic="true"
                   >
-                    {jobStatus.state === "running" && <span className="mr-2 inline-block size-4 animate-spin rounded-full border-2 border-cyan-100/30 border-t-cyan-200" />}
-                    {progressMessage(t, jobStatus.state)}
+                    <div className="flex items-center gap-2">
+                      {jobStatus.state === "running" && <span className="inline-block size-4 shrink-0 animate-spin rounded-full border-2 border-cyan-100/30 border-t-cyan-200" />}
+                      <span className="min-w-0 flex-1 truncate">{progressMessage(t, jobStatus)}</span>
+                      {jobStatus.progressPercent !== undefined && (
+                        <span className="shrink-0 tabular-nums text-cyan-50/80">{jobStatus.progressPercent}%</span>
+                      )}
+                    </div>
+                    {jobStatus.progressPercent !== undefined && (
+                      <Progress
+                        aria-label="Analysis progress"
+                        value={jobStatus.progressPercent}
+                        className="mt-2"
+                      />
+                    )}
                   </div>
                 )}
 

--- a/apps/desktop/src/lib/analysis.test.ts
+++ b/apps/desktop/src/lib/analysis.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDemoRehearsalSong } from "@bandscope/shared-types";
-import { getAnalysisJobStatus, importYoutubeUrl } from "./analysis";
+import { createDemoAnalysisJobRequest, createDemoRehearsalSong } from "@bandscope/shared-types";
+import { getAnalysisJobStatus, importYoutubeUrl, startAnalysisJob } from "./analysis";
 
 type TauriWindow = Window & {
   __TAURI_INTERNALS__?: unknown;
@@ -110,6 +110,52 @@ describe("analysis bridge", () => {
     const status = await getAnalysisJobStatus("job-legacy");
 
     expect(status.result?.sections[0]?.timeRange).toEqual({ start: 0, end: 1 });
+  });
+
+  it("reports staged browser fallback progress before returning the demo result", async () => {
+    const queued = await startAnalysisJob(createDemoAnalysisJobRequest());
+
+    expect(queued).toMatchObject({
+      state: "queued",
+      progressLabel: "Queued for analysis",
+      progressStage: "queued",
+      progressPercent: 0
+    });
+
+    const running = await getAnalysisJobStatus(queued.jobId);
+    expect(running).toMatchObject({
+      state: "running",
+      progressLabel: "Decoding audio",
+      progressStage: "decode",
+      progressPercent: 20
+    });
+
+    expect(await getAnalysisJobStatus(queued.jobId)).toMatchObject({
+      state: "running",
+      progressLabel: "Separating stems... (45%)",
+      progressStage: "separate",
+      progressPercent: 45
+    });
+    expect(await getAnalysisJobStatus(queued.jobId)).toMatchObject({
+      state: "running",
+      progressLabel: "Building rehearsal cues",
+      progressStage: "analyze",
+      progressPercent: 70
+    });
+    expect(await getAnalysisJobStatus(queued.jobId)).toMatchObject({
+      state: "running",
+      progressLabel: "Saving reusable features",
+      progressStage: "persist",
+      progressPercent: 90
+    });
+
+    const ready = await getAnalysisJobStatus(queued.jobId);
+    expect(ready).toMatchObject({
+      state: "succeeded",
+      progressLabel: "Analysis ready",
+      progressStage: "ready",
+      progressPercent: 100
+    });
   });
 
   it("ignores a non-function Tauri v1 invoke shim", async () => {

--- a/apps/desktop/src/lib/analysis.ts
+++ b/apps/desktop/src/lib/analysis.ts
@@ -27,6 +27,12 @@ declare global {
 }
 
 const browserJobStore = new Map<string, AnalysisJobStatus>();
+const BROWSER_PROGRESS_STEPS = [
+  { progressLabel: "Decoding audio", progressStage: "decode", progressPercent: 20 },
+  { progressLabel: "Separating stems... (45%)", progressStage: "separate", progressPercent: 45 },
+  { progressLabel: "Building rehearsal cues", progressStage: "analyze", progressPercent: 70 },
+  { progressLabel: "Saving reusable features", progressStage: "persist", progressPercent: 90 }
+] as const;
 const UNSUPPORTED_LOCAL_AUDIO_MESSAGE = "Choose a WAV, MP3, FLAC, or M4A file to start analysis.";
 const SAFE_LOCAL_AUDIO_MESSAGES = new Set([
   UNSUPPORTED_LOCAL_AUDIO_MESSAGE,
@@ -106,7 +112,10 @@ async function browserFallback(command: string, args?: Record<string, unknown>):
     const queued = createAnalysisJobStatus({
       jobId,
       state: "queued",
-      progressLabel: "Queued for analysis"
+      progressLabel: "Queued for analysis",
+      progressStage: "queued",
+      progressPercent: 0,
+      cacheStatus: "disabled"
     });
     browserJobStore.set(jobId, queued);
     return queued;
@@ -129,10 +138,30 @@ async function browserFallback(command: string, args?: Record<string, unknown>):
         }
       });
     }
+    if (existing.state === "queued" || existing.state === "running") {
+      const currentPercent = existing.progressPercent ?? 0;
+      const nextStep = BROWSER_PROGRESS_STEPS.find((step) => step.progressPercent > currentPercent);
+      if (nextStep) {
+        const running = createAnalysisJobStatus({
+          jobId,
+          state: "running",
+          requestedAt: existing.requestedAt,
+          progressLabel: nextStep.progressLabel,
+          progressStage: nextStep.progressStage,
+          progressPercent: nextStep.progressPercent,
+          cacheStatus: "disabled"
+        });
+        browserJobStore.set(jobId, running);
+        return running;
+      }
+    }
     const succeeded = createAnalysisJobStatus({
       jobId,
       state: "succeeded",
       progressLabel: "Analysis ready",
+      progressStage: "ready",
+      progressPercent: 100,
+      cacheStatus: "disabled",
       requestedAt: existing.requestedAt,
       result: createDemoRehearsalSong()
     });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -177,6 +177,10 @@ export type AnalysisSourceKind = "demo" | "local_audio";
 /** Documented. */
 export type AnalysisJobState = "queued" | "running" | "succeeded" | "failed";
 /** Documented. */
+export type AnalysisJobStage = "queued" | "decode" | "separate" | "analyze" | "persist" | "ready";
+/** Documented. */
+export type AnalysisCacheStatus = "disabled" | "miss" | "hit" | "stored";
+/** Documented. */
 export type AnalysisJobErrorCode = "invalid_request" | "not_found" | "engine_unavailable";
 
 /** Documented. */
@@ -271,6 +275,9 @@ export type AnalysisJobStatus = {
   requestedAt: string;
   updatedAt: string;
   progressLabel?: string;
+  progressStage?: AnalysisJobStage;
+  progressPercent?: number;
+  cacheStatus?: AnalysisCacheStatus;
   result?: RehearsalSong;
   error?: AnalysisJobError;
 };
@@ -294,6 +301,8 @@ const ROLE_TYPES = ["instrument", "vocal", "hand"] as const;
 const EXPORT_FORMATS = ["cue-sheet", "chart-summary"] as const;
 const ANALYSIS_SOURCE_KINDS = ["demo", "local_audio"] as const;
 const ANALYSIS_JOB_STATES = ["queued", "running", "succeeded", "failed"] as const;
+const ANALYSIS_JOB_STAGES = ["queued", "decode", "separate", "analyze", "persist", "ready"] as const;
+const ANALYSIS_CACHE_STATUSES = ["disabled", "miss", "hit", "stored"] as const;
 const ANALYSIS_JOB_ERROR_CODES = ["invalid_request", "not_found", "engine_unavailable"] as const;
 const PACK_STATES = ["queued", "analyzing", "ready", "failed"] as const;
 const HANDOFF_ASSET_STATUSES = ["referenced", "missing"] as const;
@@ -798,6 +807,9 @@ export function createAnalysisJobStatus(input:
       jobId: string;
       state: "queued" | "running";
       progressLabel?: string;
+      progressStage?: AnalysisJobStage;
+      progressPercent?: number;
+      cacheStatus?: AnalysisCacheStatus;
       requestedAt?: string;
       updatedAt?: string;
     }
@@ -806,6 +818,9 @@ export function createAnalysisJobStatus(input:
       state: "succeeded";
       result: RehearsalSong;
       progressLabel?: string;
+      progressStage?: AnalysisJobStage;
+      progressPercent?: number;
+      cacheStatus?: AnalysisCacheStatus;
       requestedAt?: string;
       updatedAt?: string;
     }
@@ -814,6 +829,9 @@ export function createAnalysisJobStatus(input:
       state: "failed";
       error: AnalysisJobError;
       progressLabel?: string;
+      progressStage?: AnalysisJobStage;
+      progressPercent?: number;
+      cacheStatus?: AnalysisCacheStatus;
       requestedAt?: string;
       updatedAt?: string;
     }
@@ -828,6 +846,15 @@ export function createAnalysisJobStatus(input:
 
   if (input.progressLabel !== undefined) {
     status.progressLabel = input.progressLabel;
+  }
+  if (input.progressStage !== undefined) {
+    status.progressStage = input.progressStage;
+  }
+  if (input.progressPercent !== undefined) {
+    status.progressPercent = input.progressPercent;
+  }
+  if (input.cacheStatus !== undefined) {
+    status.cacheStatus = input.cacheStatus;
   }
   if ("result" in input) {
     status.result = input.result;
@@ -915,10 +942,10 @@ function validateAnalysisJobStatus(
     return invalidField("root");
   }
   const allowedKeysByState: Record<AnalysisJobState, string[]> = {
-    queued: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel"],
-    running: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel"],
-    succeeded: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "result"],
-    failed: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "error"]
+    queued: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "progressStage", "progressPercent", "cacheStatus"],
+    running: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "progressStage", "progressPercent", "cacheStatus"],
+    succeeded: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "progressStage", "progressPercent", "cacheStatus", "result"],
+    failed: ["jobId", "state", "requestedAt", "updatedAt", "progressLabel", "progressStage", "progressPercent", "cacheStatus", "error"]
   };
   if (typeof value.jobId !== "string") {
     return invalidField("jobId");
@@ -938,6 +965,23 @@ function validateAnalysisJobStatus(
   }
   if (value.progressLabel !== undefined && typeof value.progressLabel !== "string") {
     return invalidField("progressLabel");
+  }
+  if (value.progressStage !== undefined && !isOneOf(ANALYSIS_JOB_STAGES, value.progressStage)) {
+    return invalidField("progressStage");
+  }
+  if (
+    value.progressPercent !== undefined &&
+    (
+      typeof value.progressPercent !== "number" ||
+      !Number.isInteger(value.progressPercent) ||
+      value.progressPercent < 0 ||
+      value.progressPercent > 100
+    )
+  ) {
+    return invalidField("progressPercent");
+  }
+  if (value.cacheStatus !== undefined && !isOneOf(ANALYSIS_CACHE_STATUSES, value.cacheStatus)) {
+    return invalidField("cacheStatus");
   }
   if (value.result !== undefined) {
     const resultError = validateRehearsalSong(value.result, options);

--- a/packages/shared-types/test/index.test.ts
+++ b/packages/shared-types/test/index.test.ts
@@ -79,7 +79,10 @@ describe("shared type helpers", () => {
     const queuedStatus = createAnalysisJobStatus({
       jobId: "job-queued",
       state: "queued",
-      progressLabel: "Queued for analysis"
+      progressLabel: "Queued for analysis",
+      progressStage: "queued",
+      progressPercent: 0,
+      cacheStatus: "disabled"
     });
     const failedStatus = createAnalysisJobStatus({
       jobId: "job-failed",
@@ -153,8 +156,37 @@ describe("shared type helpers", () => {
       state: "queued",
       requestedAt: queuedStatus.requestedAt,
       updatedAt: queuedStatus.updatedAt,
-      progressLabel: "Queued for analysis"
+      progressLabel: "Queued for analysis",
+      progressStage: "queued",
+      progressPercent: 0,
+      cacheStatus: "disabled"
     });
+    expect(isAnalysisJobStatus({
+      jobId: "job-1",
+      state: "running",
+      requestedAt: "2026-03-12T00:00:00.000Z",
+      updatedAt: "2026-03-12T00:00:01.000Z",
+      progressLabel: "Separating stems... (45%)",
+      progressStage: "separate",
+      progressPercent: 45,
+      cacheStatus: "miss"
+    })).toBe(true);
+    expect(isAnalysisJobStatus({
+      jobId: "job-1",
+      state: "running",
+      requestedAt: "2026-03-12T00:00:00.000Z",
+      updatedAt: "2026-03-12T00:00:01.000Z",
+      progressStage: "not-a-stage",
+      progressPercent: 45
+    })).toBe(false);
+    expect(isAnalysisJobStatus({
+      jobId: "job-1",
+      state: "running",
+      requestedAt: "2026-03-12T00:00:00.000Z",
+      updatedAt: "2026-03-12T00:00:01.000Z",
+      progressStage: "separate",
+      progressPercent: 101
+    })).toBe(false);
     expect(isAnalysisJobStatus({
       jobId: "job-1",
       state: "failed",

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+from pathlib import Path
 from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from bandscope_analysis.health import HealthReport, build_health_report
@@ -9,6 +12,11 @@ from bandscope_analysis.roles import RoleExtractor
 from bandscope_analysis.sections import extract_sections
 
 MAX_SECTION_TIME_SECONDS = 4_294_967_295
+ANALYSIS_CACHE_SCHEMA_VERSION = 1
+
+AnalysisJobState = Literal["queued", "running", "succeeded", "failed"]
+AnalysisJobStage = Literal["queued", "decode", "separate", "analyze", "persist", "ready"]
+AnalysisCacheStatus = Literal["disabled", "miss", "hit", "stored"]
 
 
 class AnalysisJobRequest(TypedDict):
@@ -19,6 +27,8 @@ class AnalysisJobRequest(TypedDict):
     roleFocus: list[str]
     projectId: NotRequired[str]
     localSource: NotRequired[LocalAudioSource]
+    cacheRoot: NotRequired[str]
+    tempRoot: NotRequired[str]
 
 
 class LocalAudioSource(TypedDict):
@@ -141,12 +151,23 @@ class AnalysisJobStatus(TypedDict):
     """Typed analysis job snapshot shared with the desktop orchestrator."""
 
     jobId: str
-    state: Literal["queued", "running", "succeeded", "failed"]
+    state: AnalysisJobState
     requestedAt: str
     updatedAt: str
     progressLabel: NotRequired[str]
+    progressStage: NotRequired[AnalysisJobStage]
+    progressPercent: NotRequired[int]
+    cacheStatus: NotRequired[AnalysisCacheStatus]
     result: NotRequired[RehearsalSong]
     error: NotRequired[AnalysisJobError]
+
+
+class CachedAnalysisPayload(TypedDict):
+    """Typed cached analysis payload persisted below the app-owned cache root."""
+
+    schemaVersion: int
+    source: dict[str, object]
+    result: RehearsalSong
 
 
 def build_section_time_range(start: object, end: object) -> SectionTimeRangePayload:
@@ -179,7 +200,15 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
     if not isinstance(payload, dict):
         raise ValueError("Invalid analysis job request: invalid field 'root'")
 
-    allowed_keys = {"sourceKind", "sourceLabel", "roleFocus", "projectId", "localSource"}
+    allowed_keys = {
+        "sourceKind",
+        "sourceLabel",
+        "roleFocus",
+        "projectId",
+        "localSource",
+        "cacheRoot",
+        "tempRoot",
+    }
     for key in payload:
         if key not in allowed_keys:
             raise ValueError(f"Invalid analysis job request: invalid field '{key}'")
@@ -188,6 +217,8 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
     source_label = payload.get("sourceLabel")
     role_focus = payload.get("roleFocus")
     project_id = payload.get("projectId")
+    cache_root = payload.get("cacheRoot")
+    temp_root = payload.get("tempRoot")
 
     if source_kind not in {"demo", "local_audio"}:
         raise ValueError("Invalid analysis job request: invalid field 'sourceKind'")
@@ -203,6 +234,10 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
     if source_kind == "demo":
         if local_source is not None or project_id is not None:
             raise ValueError("Invalid analysis job request: invalid field 'projectId'")
+        if cache_root is not None:
+            raise ValueError("Invalid analysis job request: invalid field 'cacheRoot'")
+        if temp_root is not None:
+            raise ValueError("Invalid analysis job request: invalid field 'tempRoot'")
         return {
             "sourceKind": source_kind,
             "sourceLabel": source_label,
@@ -232,7 +267,7 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
     if not isinstance(file_size_bytes, int) or file_size_bytes <= 0:
         raise ValueError("Invalid analysis job request: invalid field 'localSource.fileSizeBytes'")
 
-    return {
+    normalized: AnalysisJobRequest = {
         "sourceKind": source_kind,
         "sourceLabel": source_label,
         "roleFocus": role_focus,
@@ -244,6 +279,16 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
             "fileSizeBytes": file_size_bytes,
         },
     }
+    if cache_root is not None:
+        if not isinstance(cache_root, str) or not cache_root.strip():
+            raise ValueError("Invalid analysis job request: invalid field 'cacheRoot'")
+        normalized["cacheRoot"] = cache_root
+    if temp_root is not None:
+        if not isinstance(temp_root, str) or not temp_root.strip():
+            raise ValueError("Invalid analysis job request: invalid field 'tempRoot'")
+        normalized["tempRoot"] = temp_root
+
+    return normalized
 
 
 def build_demo_rehearsal_song() -> RehearsalSong:
@@ -286,27 +331,219 @@ def build_demo_rehearsal_song() -> RehearsalSong:
     }
 
 
-def run_analysis_job(job_id: str, payload: object, requested_at: str) -> AnalysisJobStatus:
-    """Return a structured orchestration response for a validated analysis job."""
+def _build_job_status(
+    *,
+    job_id: str,
+    state: AnalysisJobState,
+    requested_at: str,
+    progress_label: str | None = None,
+    progress_stage: AnalysisJobStage | None = None,
+    progress_percent: int | None = None,
+    cache_status: AnalysisCacheStatus | None = None,
+    result: RehearsalSong | None = None,
+    error: AnalysisJobError | None = None,
+) -> AnalysisJobStatus:
+    """Build a shared job status envelope with optional orchestration progress."""
+    status: AnalysisJobStatus = {
+        "jobId": job_id,
+        "state": state,
+        "requestedAt": requested_at,
+        "updatedAt": requested_at,
+    }
+    if progress_label is not None:
+        status["progressLabel"] = progress_label
+    if progress_stage is not None:
+        status["progressStage"] = progress_stage
+    if progress_percent is not None:
+        status["progressPercent"] = progress_percent
+    if cache_status is not None:
+        status["cacheStatus"] = cache_status
+    if result is not None:
+        status["result"] = result
+    if error is not None:
+        status["error"] = error
+    return status
+
+
+def _analysis_cache_path(request: AnalysisJobRequest) -> Path | None:
+    """Return the per-track cache path for a local-audio request when caching is enabled."""
+    if request["sourceKind"] != "local_audio" or "localSource" not in request:
+        return None
+    cache_root = request.get("cacheRoot")
+    if not cache_root:
+        return None
+
+    local_source = request["localSource"]
+    key_payload = {
+        "schemaVersion": ANALYSIS_CACHE_SCHEMA_VERSION,
+        "projectId": request.get("projectId", ""),
+        "sourcePath": local_source["sourcePath"],
+        "fileName": local_source["fileName"],
+        "fileSizeBytes": local_source["fileSizeBytes"],
+    }
+    digest = hashlib.sha256(
+        json.dumps(key_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return Path(cache_root) / "analysis-cache-v1" / f"{digest}.json"
+
+
+def _load_cached_analysis(path: Path) -> RehearsalSong | None:
+    """Load a cached rehearsal result, treating malformed cache as a miss."""
+    try:
+        with path.open("r", encoding="utf-8") as cache_file:
+            payload = json.load(cache_file)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schemaVersion") != ANALYSIS_CACHE_SCHEMA_VERSION:
+        return None
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return None
+    return cast(RehearsalSong, result)
+
+
+def _store_cached_analysis(path: Path, request: AnalysisJobRequest, result: RehearsalSong) -> bool:
+    """Persist cache metadata without storing the original absolute source path."""
+    if "localSource" not in request:
+        return False
+
+    local_source = request["localSource"]
+    payload: CachedAnalysisPayload = {
+        "schemaVersion": ANALYSIS_CACHE_SCHEMA_VERSION,
+        "source": {
+            "fileName": local_source["fileName"],
+            "extension": local_source["extension"],
+            "fileSizeBytes": local_source["fileSizeBytes"],
+        },
+        "result": result,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_suffix(".tmp")
+        with temp_path.open("w", encoding="utf-8") as cache_file:
+            json.dump(payload, cache_file, separators=(",", ":"))
+        temp_path.replace(path)
+    except OSError:
+        return False
+    return True
+
+
+def run_analysis_job_updates(
+    job_id: str,
+    payload: object,
+    requested_at: str,
+) -> list[AnalysisJobStatus]:
+    """Return incremental orchestration status updates for an analysis job."""
     try:
         request = validate_analysis_job_request(payload)
     except ValueError as error:
-        return {
-            "jobId": job_id,
-            "state": "failed",
-            "requestedAt": requested_at,
-            "updatedAt": requested_at,
-            "error": {
-                "code": "invalid_request",
-                "message": str(error),
-            },
-        }
+        return [
+            _build_job_status(
+                job_id=job_id,
+                state="failed",
+                requested_at=requested_at,
+                error={
+                    "code": "invalid_request",
+                    "message": str(error),
+                },
+            )
+        ]
 
-    return {
-        "jobId": job_id,
-        "state": "succeeded",
-        "requestedAt": requested_at,
-        "updatedAt": requested_at,
-        "progressLabel": f"Analysis ready for {request['sourceLabel']}",
-        "result": build_demo_rehearsal_song(),
-    }
+    cache_path = _analysis_cache_path(request)
+    cache_status: AnalysisCacheStatus = "disabled" if cache_path is None else "miss"
+    if cache_path is not None:
+        cached_result = _load_cached_analysis(cache_path)
+        if cached_result is not None:
+            return [
+                _build_job_status(
+                    job_id=job_id,
+                    state="running",
+                    requested_at=requested_at,
+                    progress_label="Loading cached analysis",
+                    progress_stage="persist",
+                    progress_percent=95,
+                    cache_status="hit",
+                ),
+                _build_job_status(
+                    job_id=job_id,
+                    state="succeeded",
+                    requested_at=requested_at,
+                    progress_label=f"Analysis ready for {request['sourceLabel']}",
+                    progress_stage="ready",
+                    progress_percent=100,
+                    cache_status="hit",
+                    result=cached_result,
+                ),
+            ]
+
+    decode_label = (
+        "Decoding local audio" if request["sourceKind"] == "local_audio" else "Preparing demo track"
+    )
+    updates = [
+        _build_job_status(
+            job_id=job_id,
+            state="running",
+            requested_at=requested_at,
+            progress_label=decode_label,
+            progress_stage="decode",
+            progress_percent=20,
+            cache_status=cache_status,
+        ),
+        _build_job_status(
+            job_id=job_id,
+            state="running",
+            requested_at=requested_at,
+            progress_label="Separating stems... (45%)",
+            progress_stage="separate",
+            progress_percent=45,
+            cache_status=cache_status,
+        ),
+        _build_job_status(
+            job_id=job_id,
+            state="running",
+            requested_at=requested_at,
+            progress_label="Building rehearsal cues",
+            progress_stage="analyze",
+            progress_percent=70,
+            cache_status=cache_status,
+        ),
+    ]
+
+    result = build_demo_rehearsal_song()
+    updates.append(
+        _build_job_status(
+            job_id=job_id,
+            state="running",
+            requested_at=requested_at,
+            progress_label="Saving reusable features",
+            progress_stage="persist",
+            progress_percent=90,
+            cache_status=cache_status,
+        )
+    )
+    final_cache_status = cache_status
+    if cache_path is not None:
+        final_cache_status = (
+            "stored" if _store_cached_analysis(cache_path, request, result) else "miss"
+        )
+    updates.append(
+        _build_job_status(
+            job_id=job_id,
+            state="succeeded",
+            requested_at=requested_at,
+            progress_label=f"Analysis ready for {request['sourceLabel']}",
+            progress_stage="ready",
+            progress_percent=100,
+            cache_status=final_cache_status,
+            result=result,
+        )
+    )
+    return updates
+
+
+def run_analysis_job(job_id: str, payload: object, requested_at: str) -> AnalysisJobStatus:
+    """Return a structured orchestration response for a validated analysis job."""
+    return run_analysis_job_updates(job_id, payload, requested_at)[-1]

--- a/services/analysis-engine/src/bandscope_analysis/cli.py
+++ b/services/analysis-engine/src/bandscope_analysis/cli.py
@@ -7,10 +7,9 @@ import logging
 import sys
 from datetime import UTC, datetime
 
-from bandscope_analysis.api import get_analysis_status, run_analysis_job
+from bandscope_analysis.api import get_analysis_status, run_analysis_job, run_analysis_job_updates
 from bandscope_analysis.temporal import TemporalAnalyzer
 
-# Temporary logging setup for temporal analyzer
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
@@ -33,14 +32,16 @@ def main() -> int:
     """Read a job payload from stdin and print a structured job response to stdout."""
     # Read all input from stdin first
     input_data = sys.stdin.read().strip()
+    progress_jsonl = "--progress-jsonl" in sys.argv[1:]
+    cli_args = [arg for arg in sys.argv[1:] if arg != "--progress-jsonl"]
 
     # Check if there are command line arguments (fallback for manual testing)
-    if len(sys.argv) > 1:
-        if sys.argv[1] == "--status":
+    if cli_args:
+        if cli_args[0] == "--status":
             json.dump(get_analysis_status(), sys.stdout)
             return 0
-        elif sys.argv[1] == "--job" and len(sys.argv) > 2:
-            input_data = sys.argv[2]
+        elif cli_args[0] == "--job" and len(cli_args) > 1:
+            input_data = cli_args[1]
             if not input_data.startswith("{"):
                 try:
                     with open(input_data, "r", encoding="utf-8") as f:
@@ -81,17 +82,29 @@ def main() -> int:
         and request.get("sourceKind") == "local_audio"
         and "localSource" in request
     ):
-        audio_path = request["localSource"].get("sourcePath")
+        local_source = request["localSource"]
+        audio_path = local_source.get("sourcePath")
+        file_name = local_source.get("fileName", "selected audio")
         if audio_path:
-            logging.info(f"Extracting temporal features from {audio_path}...")
+            logging.info("Extracting temporal features from %s...", file_name)
             try:
                 temporal_analyzer = TemporalAnalyzer()
                 features = temporal_analyzer.analyze(audio_path)
                 logging.info(f"Extracted BPM: {features['bpm']}")
-            except Exception as e:
-                logging.warning(f"Temporal analysis failed, continuing with mock: {e}")
+            except Exception:
+                logging.warning(
+                    "Temporal analysis failed for %s; continuing with safe fallback.",
+                    file_name,
+                )
 
     requested_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if progress_jsonl:
+        for update in run_analysis_job_updates(job_id, request, requested_at):
+            json.dump(update, sys.stdout)
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+        return 0
+
     response = run_analysis_job(job_id, request, requested_at)
     json.dump(response, sys.stdout)
     return 0

--- a/services/analysis-engine/tests/test_api.py
+++ b/services/analysis-engine/tests/test_api.py
@@ -1,10 +1,13 @@
 """Tests for the public analysis-engine API helpers."""
 
 from bandscope_analysis.api import (
+    _load_cached_analysis,
+    _store_cached_analysis,
     build_demo_rehearsal_song,
     build_section_time_range,
     get_analysis_status,
     run_analysis_job,
+    run_analysis_job_updates,
     validate_analysis_job_request,
 )
 
@@ -47,6 +50,8 @@ def test_validate_analysis_job_request_accepts_local_audio_payload() -> None:
                 "extension": "wav",
                 "fileSizeBytes": 1024000,
             },
+            "cacheRoot": "/tmp/bandscope/cache/project-1",
+            "tempRoot": "/tmp/bandscope/temp/project-1",
         }
     ) == {
         "sourceKind": "local_audio",
@@ -59,6 +64,8 @@ def test_validate_analysis_job_request_accepts_local_audio_payload() -> None:
             "extension": "wav",
             "fileSizeBytes": 1024000,
         },
+        "cacheRoot": "/tmp/bandscope/cache/project-1",
+        "tempRoot": "/tmp/bandscope/temp/project-1",
     }
 
 
@@ -190,6 +197,56 @@ def test_validate_analysis_job_request_rejects_bad_payloads() -> None:
             {"sourceKind": "demo", "sourceLabel": "Late Night Set", "roleFocus": [], "extra": True},
             "extra",
         ),
+        (
+            {
+                "sourceKind": "demo",
+                "sourceLabel": "Late Night Set",
+                "roleFocus": [],
+                "cacheRoot": "/tmp/bandscope/cache",
+            },
+            "cacheRoot",
+        ),
+        (
+            {
+                "sourceKind": "demo",
+                "sourceLabel": "Late Night Set",
+                "roleFocus": [],
+                "tempRoot": "/tmp/bandscope/temp",
+            },
+            "tempRoot",
+        ),
+        (
+            {
+                "sourceKind": "local_audio",
+                "projectId": "project-1",
+                "sourceLabel": "Late Night Set",
+                "roleFocus": [],
+                "localSource": {
+                    "sourcePath": "/Users/test/Music/late-night-set.wav",
+                    "fileName": "late-night-set.wav",
+                    "extension": "wav",
+                    "fileSizeBytes": 1024000,
+                },
+                "cacheRoot": " ",
+            },
+            "cacheRoot",
+        ),
+        (
+            {
+                "sourceKind": "local_audio",
+                "projectId": "project-1",
+                "sourceLabel": "Late Night Set",
+                "roleFocus": [],
+                "localSource": {
+                    "sourcePath": "/Users/test/Music/late-night-set.wav",
+                    "fileName": "late-night-set.wav",
+                    "extension": "wav",
+                    "fileSizeBytes": 1024000,
+                },
+                "tempRoot": [],
+            },
+            "tempRoot",
+        ),
     ]
 
     for payload, message in cases:
@@ -287,3 +344,91 @@ def test_run_analysis_job_returns_success_for_local_audio_request() -> None:
 
     assert success["state"] == "succeeded"
     assert success["progressLabel"] == "Analysis ready for late-night-set.wav"
+
+
+def test_run_analysis_job_updates_report_progress_and_cache(tmp_path) -> None:
+    """Ensure local-audio orchestration exposes stages and persists reusable cache."""
+    payload = {
+        "sourceKind": "local_audio",
+        "projectId": "project-cache",
+        "sourceLabel": "late-night-set.wav",
+        "roleFocus": ["bass-guitar"],
+        "localSource": {
+            "sourcePath": "/Users/test/Music/late-night-set.wav",
+            "fileName": "late-night-set.wav",
+            "extension": "wav",
+            "fileSizeBytes": 1024000,
+        },
+        "cacheRoot": str(tmp_path / "cache"),
+        "tempRoot": str(tmp_path / "temp"),
+    }
+
+    updates = list(run_analysis_job_updates("job-cache", payload, "2026-03-12T00:00:00Z"))
+
+    observed_progress = [
+        (update["state"], update["progressStage"], update["progressPercent"]) for update in updates
+    ]
+    assert observed_progress == [
+        ("running", "decode", 20),
+        ("running", "separate", 45),
+        ("running", "analyze", 70),
+        ("running", "persist", 90),
+        ("succeeded", "ready", 100),
+    ]
+    assert updates[-1]["cacheStatus"] == "stored"
+    assert len(list((tmp_path / "cache" / "analysis-cache-v1").glob("*.json"))) == 1
+
+    cached_updates = list(run_analysis_job_updates("job-cache-2", payload, "2026-03-12T00:00:00Z"))
+
+    assert cached_updates[-1]["state"] == "succeeded"
+    assert cached_updates[-1]["progressStage"] == "ready"
+    assert cached_updates[-1]["progressPercent"] == 100
+    assert cached_updates[-1]["cacheStatus"] == "hit"
+
+
+def test_cached_analysis_helpers_treat_invalid_cache_as_miss(tmp_path) -> None:
+    """Ensure malformed cache files degrade to cache misses without failing analysis."""
+    cache_path = tmp_path / "analysis-cache.json"
+
+    for content in (
+        "[]",
+        '{"schemaVersion": 999, "result": {}}',
+        '{"schemaVersion": 1, "result": []}',
+    ):
+        cache_path.write_text(content, encoding="utf-8")
+        assert _load_cached_analysis(cache_path) is None
+
+
+def test_cached_analysis_store_handles_unsupported_requests_and_write_errors(tmp_path) -> None:
+    """Ensure cache persistence failures do not block analysis results."""
+    demo_request = validate_analysis_job_request(
+        {
+            "sourceKind": "demo",
+            "sourceLabel": "Late Night Set",
+            "roleFocus": ["bass-guitar"],
+        }
+    )
+    assert (
+        _store_cached_analysis(
+            tmp_path / "demo-cache.json",
+            demo_request,
+            build_demo_rehearsal_song(),
+        )
+        is False
+    )
+
+    local_request = validate_analysis_job_request(
+        {
+            "sourceKind": "local_audio",
+            "projectId": "project-cache",
+            "sourceLabel": "late-night-set.wav",
+            "roleFocus": ["bass-guitar"],
+            "localSource": {
+                "sourcePath": "/Users/test/Music/late-night-set.wav",
+                "fileName": "late-night-set.wav",
+                "extension": "wav",
+                "fileSizeBytes": 1024000,
+            },
+        }
+    )
+    assert _store_cached_analysis(tmp_path, local_request, build_demo_rehearsal_song()) is False

--- a/services/analysis-engine/tests/test_cli.py
+++ b/services/analysis-engine/tests/test_cli.py
@@ -380,3 +380,53 @@ def test_cli_main_temporal_analyzer_mock_success(monkeypatch: pytest.MonkeyPatch
     assert cli.main() == 0
     res = json.loads(stdout.getvalue())
     assert res["jobId"] == "job-audio-success"
+
+
+def test_cli_main_progress_jsonl_streams_status_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Ensure Tauri can consume incremental job status updates from stdout."""
+    stdin = io.StringIO(
+        json.dumps(
+            {
+                "jobId": "job-progress",
+                "request": {
+                    "sourceKind": "local_audio",
+                    "projectId": "p1",
+                    "sourceLabel": "test.wav",
+                    "roleFocus": [],
+                    "localSource": {
+                        "sourcePath": "/valid/path.wav",
+                        "fileName": "test.wav",
+                        "extension": "wav",
+                        "fileSizeBytes": 100,
+                    },
+                    "cacheRoot": str(tmp_path / "cache"),
+                    "tempRoot": str(tmp_path / "temp"),
+                },
+            }
+        )
+    )
+    stdout = io.StringIO()
+
+    class FakeAnalyzerSuccess:
+        def analyze(self, path):
+            return {"bpm": 120.0, "beats": []}
+
+    monkeypatch.setattr(cli, "TemporalAnalyzer", FakeAnalyzerSuccess)
+    monkeypatch.setattr(cli.sys, "stdin", stdin)
+    monkeypatch.setattr(cli.sys, "stdout", stdout)
+    monkeypatch.setattr(cli.sys, "argv", ["cli.py", "--progress-jsonl"])
+
+    assert cli.main() == 0
+    updates = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [update["progressStage"] for update in updates] == [
+        "decode",
+        "separate",
+        "analyze",
+        "persist",
+        "ready",
+    ]
+    assert updates[-1]["state"] == "succeeded"
+    assert updates[-1]["progressPercent"] == 100


### PR DESCRIPTION
## Summary
- Extend `AnalysisJobStatus` with staged progress, percentage, and cache status fields shared across TS, Rust, and Python.
- Stream Python analysis status updates as JSONL through the Tauri IPC bridge so the desktop UI can poll multi-stage progress.
- Add app-cache-root-backed analysis cache plumbing and safe cache-miss degradation for malformed or unwritable cache files.
- Render the engine-provided progress label and accessible progressbar in the desktop source controls.

Refs #109

## Security Notes
- Local audio metadata, cache roots, temp roots, and IPC status payloads remain treated as untrusted inputs and are schema-validated before crossing boundaries.
- The renderer still cannot provide arbitrary cache/temp paths; Tauri resolves app-owned roots from the selected bootstrap source and injects them into the engine request.
- Cache writes use a hashed filename below the provided cache root and store only non-path source metadata plus the result payload; original absolute source paths are not written into cache contents.
- Malformed cache files and cache write failures degrade to cache miss/successful analysis rather than exposing raw filesystem errors to the UI.
- Temporal analyzer CLI logging now reports the selected file name instead of the absolute source path, reducing local path disclosure in stderr/log captures.

## Verification
- `./scripts/harness/quickcheck.sh`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`
- Browser check: `http://127.0.0.1:5173/` fallback analysis showed `Decoding audio` with `aria-valuenow=20` and selected source visible.
