### PR TITLE
feat: add local audio stem separation

### DIFF
--- a/services/analysis-engine/pyproject.toml
+++ b/services/analysis-engine/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "librosa>=0.11.0",
     "numba<0.66.0",
+    "numpy>=1.26.0",
     "soundfile>=0.13.1",
     "urllib3>=2.7.0",
     "yt-dlp>=2026.3.17",

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, NotRequired, TypedDict, cast
 from bandscope_analysis.health import HealthReport, build_health_report
 from bandscope_analysis.roles import RoleExtractor
 from bandscope_analysis.sections import extract_sections
+from bandscope_analysis.separation import AudioStemSeparator
 
 MAX_SECTION_TIME_SECONDS = 4_294_967_295
 ANALYSIS_CACHE_SCHEMA_VERSION = 1
@@ -291,7 +292,7 @@ def validate_analysis_job_request(payload: object) -> AnalysisJobRequest:
     return normalized
 
 
-def build_demo_rehearsal_song() -> RehearsalSong:
+def build_demo_rehearsal_song(audio_features: dict[str, Any] | None = None) -> RehearsalSong:
     """Return the bootstrap rehearsal song payload for orchestration tests."""
 
     # Extract sections using the new pipeline
@@ -301,7 +302,7 @@ def build_demo_rehearsal_song() -> RehearsalSong:
 
     # Extract roles
     extractor = RoleExtractor()
-    role_result = extractor.extract([verse_section])
+    role_result = extractor.extract([verse_section], audio_features)
     verse_topology = role_result["topologies"][0]
     verse_roles = verse_topology["active_roles"]
 
@@ -431,6 +432,23 @@ def _store_cached_analysis(path: Path, request: AnalysisJobRequest, result: Rehe
     return True
 
 
+def _build_local_audio_features(request: AnalysisJobRequest) -> dict[str, Any] | None:
+    """Build downstream audio features for a local-audio request."""
+    if request["sourceKind"] != "local_audio" or "localSource" not in request:
+        return None
+
+    separation_result = AudioStemSeparator().separate(request["localSource"]["sourcePath"])
+    return {
+        "stems": separation_result["stems"],
+        "sr": separation_result["sample_rate"],
+        "separation": {
+            "duration_seconds": separation_result["duration_seconds"],
+            "chunk_count": separation_result["chunk_count"],
+            "notes": separation_result["separation_notes"],
+        },
+    }
+
+
 def run_analysis_job_updates(
     job_id: str,
     payload: object,
@@ -501,6 +519,29 @@ def run_analysis_job_updates(
             progress_percent=45,
             cache_status=cache_status,
         ),
+    ]
+
+    try:
+        audio_features = _build_local_audio_features(request)
+    except (FileNotFoundError, ValueError) as error:
+        updates.append(
+            _build_job_status(
+                job_id=job_id,
+                state="failed",
+                requested_at=requested_at,
+                progress_label="Stem separation failed",
+                progress_stage="separate",
+                progress_percent=45,
+                cache_status=cache_status,
+                error={
+                    "code": "engine_unavailable",
+                    "message": f"Stem separation failed: {error}",
+                },
+            )
+        )
+        return updates
+
+    updates.append(
         _build_job_status(
             job_id=job_id,
             state="running",
@@ -509,10 +550,10 @@ def run_analysis_job_updates(
             progress_stage="analyze",
             progress_percent=70,
             cache_status=cache_status,
-        ),
-    ]
+        )
+    )
 
-    result = build_demo_rehearsal_song()
+    result = build_demo_rehearsal_song(audio_features)
     updates.append(
         _build_job_status(
             job_id=job_id,

--- a/services/analysis-engine/src/bandscope_analysis/separation/__init__.py
+++ b/services/analysis-engine/src/bandscope_analysis/separation/__init__.py
@@ -1,9 +1,24 @@
-"""Source separation module for categorizing roles into stem groups."""
+"""Source separation module for audio stems and role stem groups."""
 
-from .model import SeparationResult, StemCategory, StemDescriptor
+from .audio_separator import AudioSeparationConfig, AudioStemSeparator
+from .model import (
+    AudioSeparationResult,
+    AudioStemArray,
+    AudioStemName,
+    AudioStemPayload,
+    SeparationResult,
+    StemCategory,
+    StemDescriptor,
+)
 from .separator import StemSeparator
 
 __all__ = [
+    "AudioSeparationConfig",
+    "AudioSeparationResult",
+    "AudioStemArray",
+    "AudioStemName",
+    "AudioStemPayload",
+    "AudioStemSeparator",
     "StemSeparator",
     "StemCategory",
     "StemDescriptor",

--- a/services/analysis-engine/src/bandscope_analysis/separation/audio_separator.py
+++ b/services/analysis-engine/src/bandscope_analysis/separation/audio_separator.py
@@ -1,0 +1,199 @@
+"""Local audio source separation using bounded DSP heuristics."""
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import librosa
+import numpy as np
+
+from bandscope_analysis.temporal.analyzer import (
+    KNOWN_LIBROSA_NUMBA_WARNING_FILTERS,
+    MAX_ANALYSIS_DURATION_SECONDS,
+    MAX_AUDIO_FILE_BYTES,
+    TARGET_SR,
+)
+
+from .model import AudioSeparationResult, AudioStemArray, AudioStemName, AudioStemPayload
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AudioSeparationConfig:
+    """Resource and band-split settings for local stem separation."""
+
+    target_sample_rate: int = TARGET_SR
+    max_file_bytes: int = MAX_AUDIO_FILE_BYTES
+    max_duration_seconds: float = float(MAX_ANALYSIS_DURATION_SECONDS)
+    chunk_duration_seconds: float = 30.0
+    bass_cutoff_hz: float = 250.0
+    vocal_low_hz: float = 300.0
+    vocal_high_hz: float = 3_400.0
+    drum_low_hz: float = 3_400.0
+
+
+class AudioStemSeparator:
+    """Split a selected local mix into canonical stems for downstream analysis.
+
+    Security Notes:
+    - Treats the selected audio file as untrusted input.
+    - Normalizes the path before use, verifies it is a file, and enforces a
+      maximum byte size before decoder handoff.
+    - Uses librosa in-process only; no network access, model download, shell
+      execution, or user-controlled output path is introduced.
+    - Does not log or persist raw audio, separated stems, or full source paths.
+    - Fails with bounded, filename-scoped errors so callers can surface a safe
+      analysis failure without leaking local directory structure.
+    """
+
+    def __init__(self, config: AudioSeparationConfig | None = None) -> None:
+        """Initialize the local stem separator."""
+        self.config = config or AudioSeparationConfig()
+
+    def separate(self, audio_path: str | Path) -> AudioSeparationResult:
+        """Separate local audio into vocals, bass, drums, and other stems."""
+        path = self._resolve_audio_file(audio_path)
+        audio, sample_rate = self._load_audio(path)
+        if audio.size == 0:
+            raise ValueError(f"Stem separation decode failed for {path.name}")
+
+        chunk_size = max(1, int(sample_rate * self.config.chunk_duration_seconds))
+        stem_chunks: dict[AudioStemName, list[AudioStemArray]] = {
+            "vocals": [],
+            "bass": [],
+            "drums": [],
+            "other": [],
+        }
+
+        for start in range(0, audio.size, chunk_size):
+            chunk = audio[start : start + chunk_size]
+            separated_chunk = self._separate_chunk(chunk, sample_rate)
+            for stem_name, stem_audio in separated_chunk.items():
+                stem_chunks[stem_name].append(stem_audio)
+
+        stems: AudioStemPayload = {
+            stem_name: self._fit_length(np.concatenate(chunks), audio.size)
+            for stem_name, chunks in stem_chunks.items()
+        }
+        chunk_count = max(1, len(stem_chunks["vocals"]))
+        duration_seconds = float(audio.size / sample_rate)
+        logger.info(
+            "Separated local audio into canonical stems: %d chunks, %.1f seconds",
+            chunk_count,
+            duration_seconds,
+        )
+        return {
+            "stems": stems,
+            "sample_rate": sample_rate,
+            "duration_seconds": duration_seconds,
+            "chunk_count": chunk_count,
+            "separation_notes": (
+                "Separated selected local audio into vocals, bass, drums, and other "
+                f"across {chunk_count} chunks."
+            ),
+        }
+
+    def _resolve_audio_file(self, audio_path: str | Path) -> Path:
+        """Normalize and validate the selected source path."""
+        candidate = Path(audio_path).expanduser()
+        try:
+            path = candidate.resolve(strict=True)
+        except FileNotFoundError as error:
+            raise FileNotFoundError(
+                f"Audio file not found: {candidate.name or 'selected audio'}"
+            ) from error
+        if not path.is_file():
+            raise FileNotFoundError(f"Audio file not found: {path.name or 'selected audio'}")
+        return path
+
+    def _load_audio(self, path: Path) -> tuple[AudioStemArray, int]:
+        """Load bounded mono audio without logging or exposing the full source path."""
+        try:
+            with path.open("rb") as fileobj:
+                file_size = os.fstat(fileobj.fileno()).st_size
+                if file_size > self.config.max_file_bytes:
+                    raise ValueError(
+                        "Audio file is too large for stem separation: "
+                        f"{file_size} bytes (max {self.config.max_file_bytes} bytes)"
+                    )
+
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", category=DeprecationWarning, module=r"^audioread"
+                    )
+                    warnings.filterwarnings("ignore", category=FutureWarning, module=r"^audioread")
+                    for category, message, module in KNOWN_LIBROSA_NUMBA_WARNING_FILTERS:
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=category,
+                            message=message,
+                            module=module,
+                        )
+                    y, sr = librosa.load(
+                        fileobj,
+                        sr=self.config.target_sample_rate,
+                        mono=True,
+                        duration=self.config.max_duration_seconds,
+                    )
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError(f"Stem separation decode failed for {path.name}") from error
+
+        return _as_float_array(y), int(sr)
+
+    def _separate_chunk(self, chunk: AudioStemArray, sample_rate: int) -> AudioStemPayload:
+        """Split one chunk into coarse canonical frequency and percussion bands."""
+        spectrum = cast(
+            np.ndarray[Any, np.dtype[np.complexfloating[Any, Any]]],
+            np.fft.rfft(chunk),
+        )
+        frequencies = cast(
+            np.ndarray[Any, np.dtype[np.floating[Any]]],
+            np.fft.rfftfreq(chunk.size, d=1.0 / sample_rate),
+        )
+        bass_mask = frequencies <= self.config.bass_cutoff_hz
+        vocal_mask = (frequencies >= self.config.vocal_low_hz) & (
+            frequencies <= self.config.vocal_high_hz
+        )
+        drum_mask = frequencies >= self.config.drum_low_hz
+        other_mask = ~(bass_mask | vocal_mask | drum_mask)
+
+        return {
+            "vocals": _ifft_band(spectrum, vocal_mask, chunk.size),
+            "bass": _ifft_band(spectrum, bass_mask, chunk.size),
+            "drums": _ifft_band(spectrum, drum_mask, chunk.size),
+            "other": _ifft_band(spectrum, other_mask, chunk.size),
+        }
+
+    def _fit_length(self, audio: AudioStemArray, target_length: int) -> AudioStemArray:
+        """Trim or pad a stem to match the source length exactly."""
+        fitted = np.zeros(target_length, dtype=np.float32)
+        copy_length = min(target_length, int(audio.size))
+        if copy_length:
+            fitted[:copy_length] = audio[:copy_length]
+        return cast(AudioStemArray, fitted)
+
+
+def _ifft_band(
+    spectrum: np.ndarray[Any, np.dtype[np.complexfloating[Any, Any]]],
+    mask: np.ndarray[Any, np.dtype[np.bool_]],
+    target_length: int,
+) -> AudioStemArray:
+    """Convert a masked FFT spectrum into a finite float32 stem."""
+    masked = np.where(mask, spectrum, 0)
+    audio = np.fft.irfft(masked, n=target_length)
+    return _as_float_array(audio)
+
+
+def _as_float_array(values: object) -> AudioStemArray:
+    """Convert decoder and librosa output to a finite one-dimensional float array."""
+    array = np.ravel(np.asarray(values, dtype=np.float32))
+    finite = np.nan_to_num(array, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
+    return cast(AudioStemArray, finite)

--- a/services/analysis-engine/src/bandscope_analysis/separation/audio_separator.py
+++ b/services/analysis-engine/src/bandscope_analysis/separation/audio_separator.py
@@ -160,7 +160,7 @@ class AudioStemSeparator:
         )
         bass_mask = frequencies <= self.config.bass_cutoff_hz
         vocal_mask = (frequencies >= self.config.vocal_low_hz) & (
-            frequencies <= self.config.vocal_high_hz
+            frequencies < self.config.vocal_high_hz
         )
         drum_mask = frequencies >= self.config.drum_low_hz
         other_mask = ~(bass_mask | vocal_mask | drum_mask)

--- a/services/analysis-engine/src/bandscope_analysis/separation/model.py
+++ b/services/analysis-engine/src/bandscope_analysis/separation/model.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
+
+import numpy as np
+from numpy.typing import NDArray
 
 
 class StemCategory(str, Enum):
@@ -30,4 +33,19 @@ class SeparationResult(TypedDict):
     """Result returned by the source separation pipeline."""
 
     stems: list[StemDescriptor]
+    separation_notes: str
+
+
+AudioStemName = Literal["vocals", "bass", "drums", "other"]
+AudioStemArray = NDArray[np.floating[Any]]
+AudioStemPayload = dict[AudioStemName, AudioStemArray]
+
+
+class AudioSeparationResult(TypedDict):
+    """Audio stem payload returned by local source separation."""
+
+    stems: AudioStemPayload
+    sample_rate: int
+    duration_seconds: float
+    chunk_count: int
     separation_notes: str

--- a/services/analysis-engine/tests/test_api.py
+++ b/services/analysis-engine/tests/test_api.py
@@ -1,5 +1,9 @@
 """Tests for the public analysis-engine API helpers."""
 
+from unittest.mock import patch
+
+import numpy as np
+
 from bandscope_analysis.api import (
     _load_cached_analysis,
     _store_cached_analysis,
@@ -324,26 +328,49 @@ def test_run_analysis_job_handles_validation_exception() -> None:
 
 
 def test_run_analysis_job_returns_success_for_local_audio_request() -> None:
-    """Ensure local-audio requests reuse the bootstrap success envelope."""
-    success = run_analysis_job(
-        "job-3",
-        {
-            "sourceKind": "local_audio",
-            "projectId": "project-1",
-            "sourceLabel": "late-night-set.wav",
-            "roleFocus": ["bass-guitar"],
-            "localSource": {
-                "sourcePath": "/Users/test/Music/late-night-set.wav",
-                "fileName": "late-night-set.wav",
-                "extension": "wav",
-                "fileSizeBytes": 1024000,
+    """Ensure local-audio requests separate stems before building rehearsal roles."""
+    with (
+        patch("bandscope_analysis.api.AudioStemSeparator") as separator_class,
+        patch("bandscope_analysis.ranges.pitch_tracker.PitchTracker.track", return_value=None),
+        patch(
+            "bandscope_analysis.chords.chord_recognizer.ChordRecognizer.recognize",
+            return_value=[],
+        ),
+    ):
+        separator = separator_class.return_value
+        separator.separate.return_value = {
+            "stems": {
+                "vocals": np.zeros(1024),
+                "bass": np.zeros(1024),
+                "drums": np.zeros(1024),
+                "other": np.zeros(1024),
             },
-        },
-        "2026-03-12T00:00:00Z",
-    )
+            "sample_rate": 22050,
+            "duration_seconds": 1.0,
+            "chunk_count": 1,
+            "separation_notes": "Separated selected local audio into 4 canonical stems.",
+        }
+
+        success = run_analysis_job(
+            "job-3",
+            {
+                "sourceKind": "local_audio",
+                "projectId": "project-1",
+                "sourceLabel": "late-night-set.wav",
+                "roleFocus": ["bass-guitar"],
+                "localSource": {
+                    "sourcePath": "/Users/test/Music/late-night-set.wav",
+                    "fileName": "late-night-set.wav",
+                    "extension": "wav",
+                    "fileSizeBytes": 1024000,
+                },
+            },
+            "2026-03-12T00:00:00Z",
+        )
 
     assert success["state"] == "succeeded"
     assert success["progressLabel"] == "Analysis ready for late-night-set.wav"
+    separator.separate.assert_called_once_with("/Users/test/Music/late-night-set.wav")
 
 
 def test_run_analysis_job_updates_report_progress_and_cache(tmp_path) -> None:
@@ -363,27 +390,94 @@ def test_run_analysis_job_updates_report_progress_and_cache(tmp_path) -> None:
         "tempRoot": str(tmp_path / "temp"),
     }
 
-    updates = list(run_analysis_job_updates("job-cache", payload, "2026-03-12T00:00:00Z"))
+    with (
+        patch("bandscope_analysis.api.AudioStemSeparator") as separator_class,
+        patch("bandscope_analysis.ranges.pitch_tracker.PitchTracker.track", return_value=None),
+        patch(
+            "bandscope_analysis.chords.chord_recognizer.ChordRecognizer.recognize",
+            return_value=[],
+        ),
+    ):
+        separator = separator_class.return_value
+        separator.separate.return_value = {
+            "stems": {
+                "vocals": np.zeros(1024),
+                "bass": np.zeros(1024),
+                "drums": np.zeros(1024),
+                "other": np.zeros(1024),
+            },
+            "sample_rate": 22050,
+            "duration_seconds": 1.0,
+            "chunk_count": 1,
+            "separation_notes": "Separated selected local audio into 4 canonical stems.",
+        }
 
-    observed_progress = [
-        (update["state"], update["progressStage"], update["progressPercent"]) for update in updates
-    ]
-    assert observed_progress == [
-        ("running", "decode", 20),
-        ("running", "separate", 45),
-        ("running", "analyze", 70),
-        ("running", "persist", 90),
-        ("succeeded", "ready", 100),
-    ]
-    assert updates[-1]["cacheStatus"] == "stored"
-    assert len(list((tmp_path / "cache" / "analysis-cache-v1").glob("*.json"))) == 1
+        updates = list(run_analysis_job_updates("job-cache", payload, "2026-03-12T00:00:00Z"))
 
-    cached_updates = list(run_analysis_job_updates("job-cache-2", payload, "2026-03-12T00:00:00Z"))
+        observed_progress = [
+            (update["state"], update["progressStage"], update["progressPercent"])
+            for update in updates
+        ]
+        assert observed_progress == [
+            ("running", "decode", 20),
+            ("running", "separate", 45),
+            ("running", "analyze", 70),
+            ("running", "persist", 90),
+            ("succeeded", "ready", 100),
+        ]
+        assert updates[-1]["cacheStatus"] == "stored"
+        assert len(list((tmp_path / "cache" / "analysis-cache-v1").glob("*.json"))) == 1
+
+        cached_updates = list(
+            run_analysis_job_updates("job-cache-2", payload, "2026-03-12T00:00:00Z")
+        )
 
     assert cached_updates[-1]["state"] == "succeeded"
     assert cached_updates[-1]["progressStage"] == "ready"
     assert cached_updates[-1]["progressPercent"] == 100
     assert cached_updates[-1]["cacheStatus"] == "hit"
+    separator.separate.assert_called_once_with("/Users/test/Music/late-night-set.wav")
+
+
+def test_run_analysis_job_updates_fail_safely_when_local_separation_fails() -> None:
+    """Ensure unsafe or undecodable local audio returns a typed failure envelope."""
+    with patch("bandscope_analysis.api.AudioStemSeparator") as separator_class:
+        separator_class.return_value.separate.side_effect = ValueError(
+            "Audio file is too large for stem separation: 16 bytes (max 8 bytes)"
+        )
+
+        updates = list(
+            run_analysis_job_updates(
+                "job-failed-stems",
+                {
+                    "sourceKind": "local_audio",
+                    "projectId": "project-1",
+                    "sourceLabel": "late-night-set.wav",
+                    "roleFocus": ["bass-guitar"],
+                    "localSource": {
+                        "sourcePath": "/Users/test/Music/late-night-set.wav",
+                        "fileName": "late-night-set.wav",
+                        "extension": "wav",
+                        "fileSizeBytes": 1024000,
+                    },
+                },
+                "2026-03-12T00:00:00Z",
+            )
+        )
+
+    assert [(update["state"], update.get("progressStage")) for update in updates] == [
+        ("running", "decode"),
+        ("running", "separate"),
+        ("failed", "separate"),
+    ]
+    assert updates[-1]["progressPercent"] == 45
+    assert updates[-1]["error"] == {
+        "code": "engine_unavailable",
+        "message": (
+            "Stem separation failed: Audio file is too large for stem separation: "
+            "16 bytes (max 8 bytes)"
+        ),
+    }
 
 
 def test_cached_analysis_helpers_treat_invalid_cache_as_miss(tmp_path) -> None:

--- a/services/analysis-engine/tests/test_cli.py
+++ b/services/analysis-engine/tests/test_cli.py
@@ -12,7 +12,9 @@ import warnings
 from pathlib import Path
 from typing import Any, cast
 
+import numpy as np
 import pytest
+import soundfile as sf
 
 from bandscope_analysis import cli
 
@@ -39,6 +41,14 @@ def run_cli(payload: object) -> Any:
     return json.loads(completed.stdout)
 
 
+def write_short_wav(path: Path, sample_rate: int = 8_000) -> None:
+    """Write a small local-audio fixture for CLI subprocess tests."""
+    samples = sample_rate // 4
+    times = np.arange(samples, dtype=np.float32) / sample_rate
+    mix = (0.35 * np.sin(2 * np.pi * 82.0 * times)).astype(np.float32)
+    sf.write(path, mix, sample_rate)
+
+
 def test_cli_returns_succeeded_job_status_for_valid_request() -> None:
     """Ensure the CLI returns a structured succeeded status for a valid request."""
     payload = {
@@ -57,8 +67,10 @@ def test_cli_returns_succeeded_job_status_for_valid_request() -> None:
     assert cast(Any, response["result"])["title"] == "Late Night Set"
 
 
-def test_cli_returns_succeeded_job_status_for_valid_local_audio_request() -> None:
+def test_cli_returns_succeeded_job_status_for_valid_local_audio_request(tmp_path) -> None:
     """Ensure the CLI accepts the local-audio intake request shape."""
+    audio_path = tmp_path / "late-night-set.wav"
+    write_short_wav(audio_path)
     payload = {
         "jobId": "job-local-1",
         "request": {
@@ -67,10 +79,10 @@ def test_cli_returns_succeeded_job_status_for_valid_local_audio_request() -> Non
             "sourceLabel": "late-night-set.wav",
             "roleFocus": ["bass-guitar"],
             "localSource": {
-                "sourcePath": "/Users/test/Music/late-night-set.wav",
+                "sourcePath": str(audio_path),
                 "fileName": "late-night-set.wav",
                 "extension": "wav",
-                "fileSizeBytes": 1024000,
+                "fileSizeBytes": audio_path.stat().st_size,
             },
         },
     }
@@ -345,8 +357,13 @@ def test_cli_main_temporal_analyzer_mock(monkeypatch: pytest.MonkeyPatch) -> Non
     assert res["jobId"] == "job-audio"
 
 
-def test_cli_main_temporal_analyzer_mock_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_main_temporal_analyzer_mock_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
     """Ensure the temporal analyzer injection block succeeds."""
+    audio_path = tmp_path / "test.wav"
+    write_short_wav(audio_path)
     stdin = io.StringIO(
         json.dumps(
             {
@@ -357,10 +374,10 @@ def test_cli_main_temporal_analyzer_mock_success(monkeypatch: pytest.MonkeyPatch
                     "sourceLabel": "test.wav",
                     "roleFocus": [],
                     "localSource": {
-                        "sourcePath": "/valid/path.wav",
+                        "sourcePath": str(audio_path),
                         "fileName": "test.wav",
                         "extension": "wav",
-                        "fileSizeBytes": 100,
+                        "fileSizeBytes": audio_path.stat().st_size,
                     },
                 },
             }
@@ -373,6 +390,14 @@ def test_cli_main_temporal_analyzer_mock_success(monkeypatch: pytest.MonkeyPatch
             return {"bpm": 120.0, "beats": []}
 
     monkeypatch.setattr(cli, "TemporalAnalyzer", FakeAnalyzerSuccess)
+    monkeypatch.setattr(
+        "bandscope_analysis.ranges.pitch_tracker.PitchTracker.track",
+        lambda self, y, sr: None,
+    )
+    monkeypatch.setattr(
+        "bandscope_analysis.chords.chord_recognizer.ChordRecognizer.recognize",
+        lambda self, y, sr: [],
+    )
     monkeypatch.setattr(cli.sys, "stdin", stdin)
     monkeypatch.setattr(cli.sys, "stdout", stdout)
     monkeypatch.setattr(cli.sys, "argv", ["cli.py"])
@@ -387,6 +412,8 @@ def test_cli_main_progress_jsonl_streams_status_updates(
     tmp_path,
 ) -> None:
     """Ensure Tauri can consume incremental job status updates from stdout."""
+    audio_path = tmp_path / "test.wav"
+    write_short_wav(audio_path)
     stdin = io.StringIO(
         json.dumps(
             {
@@ -397,10 +424,10 @@ def test_cli_main_progress_jsonl_streams_status_updates(
                     "sourceLabel": "test.wav",
                     "roleFocus": [],
                     "localSource": {
-                        "sourcePath": "/valid/path.wav",
+                        "sourcePath": str(audio_path),
                         "fileName": "test.wav",
                         "extension": "wav",
-                        "fileSizeBytes": 100,
+                        "fileSizeBytes": audio_path.stat().st_size,
                     },
                     "cacheRoot": str(tmp_path / "cache"),
                     "tempRoot": str(tmp_path / "temp"),
@@ -415,6 +442,14 @@ def test_cli_main_progress_jsonl_streams_status_updates(
             return {"bpm": 120.0, "beats": []}
 
     monkeypatch.setattr(cli, "TemporalAnalyzer", FakeAnalyzerSuccess)
+    monkeypatch.setattr(
+        "bandscope_analysis.ranges.pitch_tracker.PitchTracker.track",
+        lambda self, y, sr: None,
+    )
+    monkeypatch.setattr(
+        "bandscope_analysis.chords.chord_recognizer.ChordRecognizer.recognize",
+        lambda self, y, sr: [],
+    )
     monkeypatch.setattr(cli.sys, "stdin", stdin)
     monkeypatch.setattr(cli.sys, "stdout", stdout)
     monkeypatch.setattr(cli.sys, "argv", ["cli.py", "--progress-jsonl"])

--- a/services/analysis-engine/tests/test_separation.py
+++ b/services/analysis-engine/tests/test_separation.py
@@ -1,5 +1,13 @@
 """Tests for the source separation module."""
 
+import numpy as np
+import pytest
+import soundfile as sf
+
+from bandscope_analysis.separation.audio_separator import (
+    AudioSeparationConfig,
+    AudioStemSeparator,
+)
 from bandscope_analysis.separation.model import StemCategory
 from bandscope_analysis.separation.separator import StemSeparator, _categorize_role
 
@@ -123,3 +131,113 @@ def test_stem_separator_keyboard_name_match() -> None:
     roles = [{"id": "synth-1", "name": "Keyboard Part", "roleType": "instrument"}]
     result = separator.separate(roles)
     assert result["stems"][0]["category"] == "keys"
+
+
+def test_audio_stem_separator_splits_local_audio_into_chunked_stems(tmp_path) -> None:
+    """Ensure local audio is separated into downstream-consumable canonical stems."""
+    sample_rate = 8_000
+    duration_seconds = 0.8
+    samples = int(sample_rate * duration_seconds)
+    times = np.arange(samples, dtype=np.float32) / sample_rate
+    click_track = np.zeros(samples, dtype=np.float32)
+    click_track[:: sample_rate // 4] = 0.8
+    mix = (
+        0.35 * np.sin(2 * np.pi * 82.0 * times)
+        + 0.25 * np.sin(2 * np.pi * 880.0 * times)
+        + click_track
+    ).astype(np.float32)
+    audio_path = tmp_path / "rehearsal.wav"
+    sf.write(audio_path, mix, sample_rate)
+
+    separator = AudioStemSeparator(
+        AudioSeparationConfig(
+            target_sample_rate=sample_rate,
+            chunk_duration_seconds=0.25,
+            max_duration_seconds=1.0,
+            max_file_bytes=1_000_000,
+        )
+    )
+
+    result = separator.separate(audio_path)
+
+    assert set(result["stems"]) == {"vocals", "bass", "drums", "other"}
+    assert result["sample_rate"] == sample_rate
+    assert result["duration_seconds"] == pytest.approx(duration_seconds)
+    assert result["chunk_count"] == 4
+    assert "4 chunks" in result["separation_notes"]
+    assert str(tmp_path) not in result["separation_notes"]
+    for stem in result["stems"].values():
+        assert stem.shape == (samples,)
+        assert np.isfinite(stem).all()
+    assert np.any(np.abs(result["stems"]["bass"]) > 0)
+    assert np.any(np.abs(result["stems"]["drums"]) > 0)
+
+
+def test_audio_stem_separator_rejects_missing_audio_file(tmp_path) -> None:
+    """Ensure missing local files fail before decode without leaking a full path."""
+    separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=8_000))
+
+    with pytest.raises(FileNotFoundError, match="Audio file not found: missing.wav"):
+        separator.separate(tmp_path / "missing.wav")
+
+
+def test_audio_stem_separator_rejects_directory_source(tmp_path) -> None:
+    """Ensure directories are not accepted as audio files."""
+    source_dir = tmp_path / "source-dir"
+    source_dir.mkdir()
+    separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=8_000))
+
+    with pytest.raises(FileNotFoundError, match="Audio file not found: source-dir"):
+        separator.separate(source_dir)
+
+
+def test_audio_stem_separator_rejects_oversized_audio_file(tmp_path) -> None:
+    """Ensure local audio intake enforces a bounded file-size limit."""
+    audio_path = tmp_path / "too-large.wav"
+    audio_path.write_bytes(b"0" * 16)
+    separator = AudioStemSeparator(
+        AudioSeparationConfig(target_sample_rate=8_000, max_file_bytes=8)
+    )
+
+    with pytest.raises(ValueError, match="Audio file is too large for stem separation"):
+        separator.separate(audio_path)
+
+
+def test_audio_stem_separator_rejects_empty_decoder_output(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure empty decoder output fails safely."""
+    audio_path = tmp_path / "empty.wav"
+    audio_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(
+        "bandscope_analysis.separation.audio_separator.librosa.load",
+        lambda *args, **kwargs: (np.array([], dtype=np.float32), 8_000),
+    )
+    separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=8_000))
+
+    with pytest.raises(ValueError, match="Stem separation decode failed for empty.wav"):
+        separator.separate(audio_path)
+
+
+def test_audio_stem_separator_redacts_decoder_exceptions(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure decoder failures are surfaced without full local paths."""
+    audio_path = tmp_path / "broken.wav"
+    audio_path.write_bytes(b"placeholder")
+
+    def fail_decode(*args, **kwargs):
+        raise RuntimeError(f"decoder failed under {tmp_path}")
+
+    monkeypatch.setattr(
+        "bandscope_analysis.separation.audio_separator.librosa.load",
+        fail_decode,
+    )
+    separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=8_000))
+
+    with pytest.raises(ValueError, match="Stem separation decode failed for broken.wav") as error:
+        separator.separate(audio_path)
+
+    assert str(tmp_path) not in str(error.value)

--- a/services/analysis-engine/tests/test_separation.py
+++ b/services/analysis-engine/tests/test_separation.py
@@ -173,6 +173,22 @@ def test_audio_stem_separator_splits_local_audio_into_chunked_stems(tmp_path) ->
     assert np.any(np.abs(result["stems"]["drums"]) > 0)
 
 
+def test_audio_stem_separator_assigns_boundary_frequency_to_drums_only() -> None:
+    """Ensure adjacent vocal and drum bands do not overlap at the boundary."""
+    sample_rate = 8_000
+    samples = 800
+    times = np.arange(samples, dtype=np.float32) / sample_rate
+    boundary_tone = np.sin(2 * np.pi * 3_400.0 * times).astype(np.float32)
+    separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=sample_rate))
+
+    stems = separator._separate_chunk(boundary_tone, sample_rate)
+
+    drum_peak = float(np.max(np.abs(stems["drums"])))
+    vocal_peak = float(np.max(np.abs(stems["vocals"])))
+    assert drum_peak > 0.5
+    assert vocal_peak < drum_peak * 0.001
+
+
 def test_audio_stem_separator_rejects_missing_audio_file(tmp_path) -> None:
     """Ensure missing local files fail before decode without leaking a full path."""
     separator = AudioStemSeparator(AudioSeparationConfig(target_sample_rate=8_000))

--- a/services/analysis-engine/uv.lock
+++ b/services/analysis-engine/uv.lock
@@ -97,6 +97,7 @@ source = { editable = "." }
 dependencies = [
     { name = "librosa" },
     { name = "numba" },
+    { name = "numpy" },
     { name = "soundfile" },
     { name = "urllib3" },
     { name = "yt-dlp" },
@@ -115,6 +116,7 @@ dev = [
 requires-dist = [
     { name = "librosa", specifier = ">=0.11.0" },
     { name = "numba", specifier = "<0.66.0" },
+    { name = "numpy", specifier = ">=1.26.0" },
     { name = "soundfile", specifier = ">=0.13.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "yt-dlp", specifier = ">=2026.3.17" },

--- a/services/analysis-engine/uv.lock
+++ b/services/analysis-engine/uv.lock
@@ -114,7 +114,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "librosa", specifier = ">=0.11.0" },
-    { name = "numba", specifier = "<0.63.0" },
+    { name = "numba", specifier = "<0.66.0" },
     { name = "soundfile", specifier = ">=0.13.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "yt-dlp", specifier = ">=2026.3.17" },


### PR DESCRIPTION
## Summary
- add a bounded local AudioStemSeparator that decodes selected audio and splits it into vocals, bass, drums, and other stems with chunked NumPy FFT bands
- feed local-audio stem payloads into RoleExtractor so downstream range/chord logic can consume real stem arrays
- return a typed safe failure at the separation stage when selected files are missing, oversized, directories, empty, or undecodable
- align uv.lock metadata with the existing pyproject numba constraint

## Tests
- ./scripts/harness/quickcheck.sh
- uv run pytest --cov=src/bandscope_analysis --cov-report=term-missing --cov-fail-under=100
- uv run mypy src
- uv run ruff check src tests

## Security Notes
- Local audio remains untrusted input: paths are normalized with strict resolution, must point to files, and are size-limited before decoder handoff.
- No model download, network inference, subprocess, shell execution, generic filesystem API, or user-controlled output path is added.
- Raw audio and separated stems stay in memory for this slice; they are not logged or persisted.
- Errors are filename-scoped so decode failures do not leak full local directory structure.
- Safe-failure tests cover missing files, directories, oversized files, empty decoder output, and decoder exceptions.

Refs #106