### PR TITLE
⚡ Bolt: O(1) lookup for active role details

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@
 ## 2026-06-13 - Memoize SongStructure timeline
 **Learning:** The SongStructure timeline component renders multiple DOM nodes for sections and re-rendered unnecessarily when the active role state changed in the parent Workspace.
 **Action:** Apply React.memo to static presentational components that receive stable props (like sections) but are siblings to highly interactive state (like role filtering).
+
+## 2025-02-13 - O(1) activeRoleDetails Lookup Optimization
+**Learning:** Recomputing active role details by looping through sections and roles on every render/selection causes repeated O(totalRoles) scans.
+**Action:** Use a memoized Map cache mapping role ID to the full RehearsalRole object to allow O(1) lookups.

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, memo } from "react";
-import type { ProjectBootstrapSummary, RehearsalSong } from "@bandscope/shared-types";
+import type { ProjectBootstrapSummary, RehearsalSong, RehearsalRole } from "@bandscope/shared-types";
 import { RoleSwitcher } from "./RoleSwitcher";
 import { SectionRoadmap } from "./SectionRoadmap";
 import { GrooveMap } from "./GrooveMap";
@@ -93,30 +93,27 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
   const t = useMemo(() => createTranslator(detectPreferredLocale()), []);
 
   // Extract all unique roles from the song's sections
-  const allRoles = useMemo(() => {
-    const roleMap = new Map<string, string>();
+  const roleMap = useMemo(() => {
+    const map = new Map<string, RehearsalRole>();
     song.sections.forEach(section => {
       section.roles.forEach(role => {
-        if (!roleMap.has(role.id)) {
-          roleMap.set(role.id, role.name);
+        if (!map.has(role.id)) {
+          map.set(role.id, role);
         }
       });
     });
-    return Array.from(roleMap.entries()).map(([id, name]) => ({ id, name }));
+    return map;
   }, [song]);
-  const activeRoleDetails = useMemo(
-    () => {
-      for (const section of song.sections) {
-        for (const role of section.roles) {
-          if (role.id === activeRole) {
-            return role;
-          }
-        }
-      }
-      return undefined;
-    },
-    [activeRole, song]
-  );
+
+  const allRoles = useMemo(() => {
+    return Array.from(roleMap.values()).map(role => ({ id: role.id, name: role.name }));
+  }, [roleMap]);
+
+  // Performance: use the cached roleMap so activeRoleDetails does not rescan sections and roles on every render.
+  const activeRoleDetails = useMemo(() => {
+    if (!activeRole) return undefined;
+    return roleMap.get(activeRole);
+  }, [activeRole, roleMap]);
   const canTranscribeBass = activeRoleDetails?.name.toLowerCase().includes("bass") ?? false;
 
   /** Documented. */


### PR DESCRIPTION
💡 What: Optimized the lookup computation for `activeRoleDetails` inside `apps/desktop/src/features/workspace/Workspace.tsx` to retrieve a role from a cached Map.
🎯 Why: Previously, finding the details of an `activeRole` involved nested $O(N \times M)$ loops through `song.sections` and `section.roles` on every component render or role selection change.
📊 Impact: This changes the `activeRoleDetails` lookup from $O(N^2)$ to $O(1)$ time complexity, ensuring smooth interactions when toggling players in workspaces featuring complex song topologies. 
🔬 Measurement: Run the application and observe rapid tab switching responsiveness within the Workspace environment. Ensured code safety by successfully running `vitest` tests for `@bandscope/desktop`.

---
*PR created automatically by Jules for task [15007825312897607835](https://jules.google.com/task/15007825312897607835) started by @seonghobae*