### PR TITLE
fix: keep Scorecard badge signal nonblocking

### DIFF
--- a/scripts/checks/normalize_scorecard_sarif.py
+++ b/scripts/checks/normalize_scorecard_sarif.py
@@ -8,6 +8,17 @@ from pathlib import Path
 
 SCORECARD_REPOSITORY_PLACEHOLDER_URI = "no file associated with this alert"
 SCORECARD_WORKFLOW_URI = ".github/workflows/ossf-scorecard.yml"
+NON_BLOCKING_SCORECARD_RULE_IDS = {
+    "CIIBestPracticesID",
+}
+
+
+def is_non_blocking_scorecard_result(result: object) -> bool:
+    """Return whether a Scorecard result should stay out of code scanning gates."""
+    return (
+        isinstance(result, dict)
+        and result.get("ruleId") in NON_BLOCKING_SCORECARD_RULE_IDS
+    )
 
 
 def normalize_scorecard_sarif(source: Path, target: Path) -> int:
@@ -24,7 +35,12 @@ def normalize_scorecard_sarif(source: Path, target: Path) -> int:
         results = run.get("results", [])
         if not isinstance(results, list):
             continue
+        retained_results = []
         for result in results:
+            if is_non_blocking_scorecard_result(result):
+                rewritten += 1
+                continue
+            retained_results.append(result)
             if not isinstance(result, dict):
                 continue
             locations = result.get("locations", [])
@@ -58,6 +74,7 @@ def normalize_scorecard_sarif(source: Path, target: Path) -> int:
                 )
                 properties["bandscopeRepositoryLevelFinding"] = True
                 rewritten += 1
+        run["results"] = retained_results
 
     target.write_text(
         json.dumps(sarif, indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -79,7 +96,7 @@ def main() -> None:
     """Normalize a Scorecard SARIF file from the command line."""
     args = parse_args()
     rewritten = normalize_scorecard_sarif(args.source, args.target)
-    print(f"Normalized {rewritten} OSSF Scorecard repository-level SARIF locations")
+    print(f"Normalized {rewritten} OSSF Scorecard SARIF entries")
 
 
 if __name__ == "__main__":

--- a/scripts/checks/normalize_scorecard_sarif.py
+++ b/scripts/checks/normalize_scorecard_sarif.py
@@ -22,7 +22,7 @@ def is_non_blocking_scorecard_result(result: object) -> bool:
 
 
 def normalize_scorecard_sarif(source: Path, target: Path) -> int:
-    """Rewrite repository-level Scorecard placeholder URIs and return change count."""
+    """Normalize Scorecard SARIF locations/results and return the change count."""
     sarif = json.loads(source.read_text(encoding="utf-8"))
     rewritten = 0
 
@@ -85,7 +85,7 @@ def normalize_scorecard_sarif(source: Path, target: Path) -> int:
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Normalize OSSF Scorecard SARIF repository-level locations."
+        description="Normalize OSSF Scorecard SARIF for GitHub code scanning upload."
     )
     parser.add_argument("source", type=Path, help="Path to the Scorecard SARIF file")
     parser.add_argument("target", type=Path, help="Path to write normalized SARIF")

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -2711,6 +2711,59 @@ def test_scorecard_sarif_normalizer_preserves_file_locations(tmp_path: Path) -> 
     assert "properties" not in location
 
 
+def test_scorecard_sarif_normalizer_drops_non_blocking_cii_badge_result(
+    tmp_path: Path,
+) -> None:
+    """Ensure the external OpenSSF badge signal does not block code scanning gates."""
+    normalizer = load_module(
+        "scripts/checks/normalize_scorecard_sarif.py",
+        "normalize_scorecard_sarif_cii_badge",
+    )
+    source = tmp_path / "results.sarif"
+    target = tmp_path / "normalized-results.sarif"
+    source.write_text(
+        json.dumps(
+            {
+                "version": "2.1.0",
+                "runs": [
+                    {
+                        "results": [
+                            {
+                                "ruleId": "CIIBestPracticesID",
+                                "message": {
+                                    "text": (
+                                        "no effort to earn an OpenSSF best practices badge detected"
+                                    )
+                                },
+                            },
+                            {
+                                "ruleId": "TokenPermissionsID",
+                                "locations": [
+                                    {
+                                        "physicalLocation": {
+                                            "artifactLocation": {
+                                                "uri": "no file associated with this alert"
+                                            }
+                                        }
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rewritten = normalizer.normalize_scorecard_sarif(source, target)
+    normalized = json.loads(target.read_text(encoding="utf-8"))
+    results = normalized["runs"][0]["results"]
+
+    assert rewritten == 2
+    assert [result["ruleId"] for result in results] == ["TokenPermissionsID"]
+
+
 def test_scorecard_sarif_normalizer_fills_existing_region_start_line(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- omit only the OpenSSF Best Practices badge Scorecard result from uploaded SARIF
- keep actionable Scorecard findings, including token permissions and vulnerabilities, in code scanning
- add a regression test for the nonblocking CII badge signal

## Verification
- uv run --project services/analysis-engine ruff check scripts/checks/normalize_scorecard_sarif.py services/analysis-engine/tests/test_supply_chain_policy.py
- uv run --project services/analysis-engine ruff format --check scripts/checks/normalize_scorecard_sarif.py services/analysis-engine/tests/test_supply_chain_policy.py
- uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q
- python3 scripts/checks/verify_supply_chain.py

## Security Notes
- Trust boundary: the Scorecard SARIF artifact remains untrusted input and still flows through the repository-owned extraction and normalization path.
- Validation: only `CIIBestPracticesID`, an external OpenSSF badge enrollment signal, is removed from code scanning upload; security-relevant Scorecard findings remain uploaded and enforced.
- Safe failure: malformed SARIF containers continue to be preserved or ignored by the existing defensive parsing behavior.
- Logging/privacy: no new logging, telemetry, network runtime path, or secret handling is added.
- Test points: regression coverage verifies CII badge suppression while preserving TokenPermissions output.
