### PR TITLE
Fix scheduler token fallback

### DIFF
--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -25,9 +25,16 @@ jobs:
     name: review and merge ready PRs
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: write
+      pull-requests: write
     env:
       DEFAULT_BRANCH: develop
-      GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN }}
+      GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}
+      OPENCODE_APPROVE_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN }}
       GH_REPO: ${{ github.repository }}
       MAX_PRS: ${{ github.event.inputs.max_prs || '20' }}
     steps:
@@ -40,9 +47,13 @@ jobs:
           repo="${GH_REPO#*/}"
 
           if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::error::pr-review-merge-scheduler requires OPENCODE_APPROVE_TOKEN with pull-requests:write and contents:write permissions."
-            echo "Configure OPENCODE_APPROVE_TOKEN before running the scheduler so branch updates and merges do not silently fall back to the read-only GITHUB_TOKEN."
+            echo "::error::pr-review-merge-scheduler requires OPENCODE_APPROVE_TOKEN or repository GITHUB_TOKEN."
             exit 1
+          fi
+          if [[ -n "${OPENCODE_APPROVE_TOKEN:-}" ]]; then
+            echo "scheduler token source=opencode-approve-token"
+          else
+            echo "scheduler token source=github-token"
           fi
 
           gh_output_retry() {

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -4907,6 +4907,21 @@ def test_opencode_review_gate_ignores_review_agent_status_contexts() -> None:
     assert workflow.count("select(opencode_review_agent_status | not)") >= 2
 
 
+def test_pr_review_merge_scheduler_uses_github_token_fallback() -> None:
+    """Ensure scheduled queue handling still runs when the app token secret is absent."""
+    repo_root = Path(__file__).resolve().parents[3]
+    workflow = (repo_root / ".github" / "workflows" / "pr-review-merge-scheduler.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "contents: write" in workflow
+    assert "issues: write" in workflow
+    assert "pull-requests: write" in workflow
+    assert "GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}" in workflow
+    assert "scheduler token source=github-token" in workflow
+    assert "Configure OPENCODE_APPROVE_TOKEN before running the scheduler" not in workflow
+
+
 def test_opencode_classifies_artifact_upload_reset_as_external() -> None:
     """Ensure transient artifact upload finalization resets do not request changes."""
     classifier = load_module(


### PR DESCRIPTION
## Summary
- let the PR review merge scheduler use the repository GITHUB_TOKEN when OPENCODE_APPROVE_TOKEN is absent
- grant the scheduler only the write scopes it already needs for PR comments, branch updates, and normal merges
- add a regression test for the fallback contract

## Tests
- actionlint .github/workflows/pr-review-merge-scheduler.yml
- python3 scripts/checks/verify_supply_chain.py
- uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q

## Security Notes
- Untrusted inputs: the scheduler still reads GitHub PR metadata only; it does not checkout or execute PR code.
- Trust boundary: fallback uses the repository-scoped GITHUB_TOKEN on the protected default-branch workflow instead of requiring a long-lived secret for every pass.
- Safe failure: the workflow still exits if no GitHub token is present and still relies on branch rules/checks for merges.
- Logging/privacy: it logs token source only, never token values.
- Test points: actionlint, supply-chain verification, and the new scheduler fallback test.