### PR TITLE
fix: wait for peer checks before OpenCode evidence

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -92,6 +92,66 @@ jobs:
         run: |
           set -euo pipefail
 
+          current_peer_checks_still_running() {
+            local owner="${GH_REPOSITORY%%/*}"
+            local name="${GH_REPOSITORY#*/}"
+
+            # Exclude this OpenCode check run; otherwise the evidence step would
+            # wait on itself until the bounded retry budget is exhausted.
+            # shellcheck disable=SC2016
+            gh api graphql \
+              -f owner="$owner" \
+              -f name="$name" \
+              -F number="$PR_NUMBER" \
+              -f query='
+                query($owner:String!,$name:String!,$number:Int!) {
+                  repository(owner:$owner,name:$name) {
+                    pullRequest(number:$number) {
+                      statusCheckRollup {
+                        contexts(first: 100) {
+                          nodes {
+                            __typename
+                            ... on CheckRun {
+                              name
+                              status
+                              checkSuite {
+                                workflowRun {
+                                  workflow {
+                                    name
+                                  }
+                                }
+                              }
+                            }
+                            ... on StatusContext {
+                              context
+                              state
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ' \
+              --jq '
+                [
+                  (.data.repository.pullRequest.statusCheckRollup.contexts.nodes // [])
+                  | .[]
+                  | if .__typename == "CheckRun" then
+                      select((.name // "") != "opencode-review")
+                      | select((.checkSuite.workflowRun.workflow.name // "") != "OpenCode PR Review")
+                      | select((.status // "") != "COMPLETED")
+                    elif .__typename == "StatusContext" then
+                      select((.context // "") != "opencode-review")
+                      | select((.state // "" | ascii_upcase) as $s | ["PENDING","EXPECTED"] | index($s))
+                    else
+                      empty
+                    end
+                ]
+                | length > 0
+              '
+          }
+
           collect_failed_check_evidence_with_wait() {
             local evidence_file="$1"
             local attempts="${FAILED_CHECK_EVIDENCE_ATTEMPTS:-19}"
@@ -100,7 +160,12 @@ jobs:
 
             while [ "$attempt" -le "$attempts" ]; do
               if scripts/ci/collect_failed_check_evidence.sh "$evidence_file"; then
-                return 0
+                if ! grep -Fq "No completed failed GitHub Checks were present" "$evidence_file"; then
+                  return 0
+                fi
+                if [ "$(current_peer_checks_still_running 2>/dev/null || printf 'false')" != "true" ]; then
+                  return 0
+                fi
               fi
 
               if [ "$attempt" -lt "$attempts" ]; then

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -4894,7 +4894,7 @@ def test_supply_chain_check_accepts_repo_workspace_exec_policy(
 
 
 def test_opencode_review_gate_ignores_review_agent_status_contexts() -> None:
-    """Ensure OpenCode approval does not wait on other review-agent statuses."""
+    """Ensure OpenCode ignores review agents while waiting on regular peer checks."""
     repo_root = Path(__file__).resolve().parents[3]
     workflow = (repo_root / ".github" / "workflows" / "opencode-review.yml").read_text(
         encoding="utf-8"
@@ -4903,7 +4903,16 @@ def test_opencode_review_gate_ignores_review_agent_status_contexts() -> None:
     assert "def opencode_review_agent_status:" in workflow
     assert '$context == "coderabbit"' in workflow
     assert '$context == "copilot pull request reviewer"' in workflow
-    assert "current_peer_checks_still_running" not in workflow
+    assert "current_peer_checks_still_running" in workflow
+    assert 'select((.name // "") != "opencode-review")' in workflow
+    assert (
+        'select((.checkSuite.workflowRun.workflow.name // "") != "OpenCode PR Review")' in workflow
+    )
+    assert (
+        'select((.state // "" | ascii_upcase) as $s | ["PENDING","EXPECTED"] | index($s))'
+        in workflow
+    )
+    assert "No completed failed GitHub Checks were present" in workflow
     assert workflow.count("select(opencode_review_agent_status | not)") >= 2
 
 


### PR DESCRIPTION
## Summary
- restore the naruon peer-check wait before OpenCode locks in failed-check evidence
- keep OpenCode from waiting on itself while ordinary pending/expected checks finish
- update the workflow source guard so review-agent contexts stay ignored but peer checks still gate evidence timing

## Verification
- actionlint .github/workflows/opencode-review.yml
- python3 scripts/checks/verify_supply_chain.py
- uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q -k 'opencode_review_gate_ignores or opencode_review_unavailable'\n- uv run --project services/analysis-engine ruff format --check services/analysis-engine/tests/test_supply_chain_policy.py\n- git diff --check\n\n## Security Notes\n- Untrusted inputs: PR check metadata is read from GitHub GraphQL and used only to decide whether bounded evidence collection should retry.\n- Trust boundary: OpenCode still excludes its own workflow/check and review-agent status contexts, so it does not wait on itself or CodeRabbit/Copilot.\n- Safe failure: GraphQL lookup failure falls back to false and the existing bounded retry/final evidence collection path remains in place.\n- Logging/privacy: no new secrets or user data are logged.\n- Test points: workflow source guard asserts the peer-check wait, self-exclusion, review-agent filtering, and unavailable-provider evidence remain present.