### PR TITLE
⚡ Bolt: [performance improvement] optimize Set allocation in GrooveMap

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -34,3 +34,6 @@
 ## 2025-02-13 - O(1) activeRoleDetails Lookup Optimization
 **Learning:** Recomputing active role details by looping through sections and roles on every render/selection causes repeated O(totalRoles) scans.
 **Action:** Use a memoized Map cache mapping role ID to the full RehearsalRole object to allow O(1) lookups.
+## 2025-02-14 - Replace Set with Map.map with for loop
+**Learning:** Using `new Set(array.map(...))` creates an unnecessary intermediate array which wastes memory allocation and garbage collection time, particularly for frequent renders of large transcription arrays.
+**Action:** Replace `array.map()` inside `new Set()` with a `for...of` loop or `.reduce()` to iterate and add elements directly to the Set for O(1) memory and avoiding intermediate array allocations.

--- a/apps/desktop/src/features/workspace/GrooveMap.tsx
+++ b/apps/desktop/src/features/workspace/GrooveMap.tsx
@@ -22,7 +22,12 @@ function GrooveMapComponent({ notes, isLoading }: GrooveMapProps) {
 
   // Unique pitches to determine vertical lanes (avoiding 88-key piano roll)
   const uniquePitches = useMemo(() => {
-    return Array.from(new Set(renderedNotes.map(n => n.pitch))).sort();
+    // Performance: Use a loop to populate the Set to avoid allocating an intermediate array from .map()
+    const pitches = new Set<string>();
+    for (const note of renderedNotes) {
+      pitches.add(note.pitch);
+    }
+    return Array.from(pitches).sort();
   }, [renderedNotes]);
 
   const pitchIndexMap = useMemo(() => {


### PR DESCRIPTION
💡 **What:**
Replaced `new Set(renderedNotes.map(n => n.pitch))` with a `for...of` loop in `apps/desktop/src/features/workspace/GrooveMap.tsx` that directly adds pitches to the Set.

🎯 **Why:**
The previous implementation used `Array.prototype.map()` before passing the result to the `Set` constructor. This maps the entire `renderedNotes` array into a new intermediate array just to extract the `pitch` strings. For large lists of transcription notes (such as a full song's bassline), this creates unnecessary memory allocation and garbage collection overhead during React renders. Populating the Set iteratively avoids this intermediate allocation entirely.

📊 **Impact:**
Removes one intermediate O(N) array allocation per render of the `GrooveMap` component when notes change, reducing memory pressure and GC pauses slightly.

🔬 **Measurement:**
I have executed `npm run test --workspace=apps/desktop` to ensure the component behaves identically, and `npm run check` to verify overall code health. The logic change ensures exact functional equivalence with fewer allocations.

---
*PR created automatically by Jules for task [5608672952137447013](https://jules.google.com/task/5608672952137447013) started by @seonghobae*