### PR TITLE
fix: refresh Rust lockfile for issue 196

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -3721,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.13.0",
  "wayland-backend",


### PR DESCRIPTION
## Summary
- refresh compatible Rust lockfile packages for the desktop app
- update `cc` to 1.2.65 and `wayland-protocols` to 0.32.13
- keep the upstream-owned `glib 0.18.5` exception tracked by #196 open

## Verification
- `cargo update --manifest-path apps/desktop/src-tauri/Cargo.toml --verbose --dry-run`
- `cargo tree --manifest-path apps/desktop/src-tauri/Cargo.toml --target all -i glib@0.18.5`
- `cargo audit --no-fetch --stale`
- `python3 scripts/checks/verify_supply_chain.py`
- `./scripts/harness/quickcheck.sh`

## Security Notes
- Untrusted inputs: no new runtime input path is introduced; this is a lockfile-only dependency refresh.
- Trust boundary: `glib 0.18.5` remains transitive through the upstream Tauri/wry/webkit2gtk/gtk stack and stays covered by repo-controlled audit/OSV exceptions.
- Safe failure: existing supply-chain checks still fail closed if the `glib` owner chain widens or the exception drifts.
- Logging/privacy: no runtime logging or user data handling changes.
- Test points: cargo owner-chain inspection, cargo audit, supply-chain verification, and full quickcheck.

Refs #196