### PR TITLE
Use OpenCode merge scheduler

### DIFF
--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -29,6 +29,11 @@ concurrency:
   group: pr-review-merge-scheduler
   cancel-in-progress: false
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: develop
+
 jobs:
   scan-pr-queue:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -1,250 +1,80 @@
-name: pr-review-merge-scheduler
+name: PR Review Merge Scheduler
 
 on:
+  schedule:
+    - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
-      max_prs:
-        description: Maximum number of open PRs to inspect in one run
+      dry_run:
+        description: Print planned actions without mutating PRs
         required: false
-        default: "20"
-  schedule:
-    - cron: "17 * * * *"
-
-permissions:
-  actions: read
-  checks: read
-  contents: read
-  pull-requests: write
+        default: false
+        type: boolean
+      max_prs:
+        description: Maximum open PRs to inspect
+        required: false
+        default: "100"
+      trigger_reviews:
+        description: Dispatch OpenCode Review for PR heads without current approval
+        required: false
+        default: false
+        type: boolean
+      enable_auto_merge:
+        description: Enable auto-merge for current-head approved PRs
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: pr-review-merge-scheduler
   cancel-in-progress: false
 
 jobs:
-  review-and-merge-ready-prs:
-    name: review and merge ready PRs
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
+  scan-pr-queue:
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: write
       checks: read
       contents: write
-      issues: write
       pull-requests: write
     env:
-      DEFAULT_BRANCH: develop
-      GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}
-      OPENCODE_APPROVE_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN }}
-      GH_REPO: ${{ github.repository }}
-      MAX_PRS: ${{ github.event.inputs.max_prs || '20' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+      MAX_PRS: ${{ inputs.max_prs || '100' }}
+      PROJECT_FLOW: ${{ vars.PROJECT_FLOW || 'git-flow' }}
+      TRIGGER_REVIEWS: "false"
+      ENABLE_AUTO_MERGE: ${{ github.event_name != 'workflow_dispatch' || inputs.enable_auto_merge == true }}
     steps:
-      - name: Inspect review state and merge eligible PRs
-        shell: bash
+      - name: Checkout trusted scheduler
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Self-test scheduler
+        run: python3 scripts/ci/pr_review_merge_scheduler.py --self-test
+
+      - name: Inspect PR review and merge queue
         run: |
           set -euo pipefail
-
-          owner="${GH_REPO%/*}"
-          repo="${GH_REPO#*/}"
-
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::error::pr-review-merge-scheduler requires OPENCODE_APPROVE_TOKEN or repository GITHUB_TOKEN."
-            exit 1
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --base-branch "$DEFAULT_BRANCH"
+            --max-prs "$MAX_PRS"
+            --project-flow "$PROJECT_FLOW"
+            --review-workflow "OpenCode Review"
+          )
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
           fi
-          if [[ -n "${OPENCODE_APPROVE_TOKEN:-}" ]]; then
-            echo "scheduler token source=opencode-approve-token"
+          if [ "$TRIGGER_REVIEWS" = "true" ]; then
+            args+=(--trigger-reviews)
           else
-            echo "scheduler token source=github-token"
+            args+=(--no-trigger-reviews)
           fi
-
-          gh_output_retry() {
-            local attempt
-            local err
-            local max_attempts=4
-            local output
-            local status
-
-            for attempt in $(seq 1 "$max_attempts"); do
-              err="$(mktemp)"
-              set +e
-              output="$("$@" 2>"$err")"
-              status="$?"
-              set -e
-
-              if [[ "$status" -eq 0 ]]; then
-                rm -f "$err"
-                printf '%s\n' "$output"
-                return 0
-              fi
-
-              if [[ "$attempt" -eq "$max_attempts" ]]; then
-                if [[ -n "$output" ]]; then
-                  printf 'stdout:\n%s\n' "$output" >&2
-                fi
-                if [[ -s "$err" ]]; then
-                  cat "$err" >&2
-                fi
-                rm -f "$err"
-                return "$status"
-              fi
-
-              echo "GitHub command failed on attempt $attempt/$max_attempts; retrying..." >&2
-              if [[ -n "$output" ]]; then
-                printf 'stdout:\n%s\n' "$output" >&2
-              fi
-              if [[ -s "$err" ]]; then
-                cat "$err" >&2
-              fi
-              rm -f "$err"
-              sleep "$((attempt * 2))"
-            done
-          }
-
-          unresolved_threads() {
-            local pr="$1"
-            # shellcheck disable=SC2016
-            gh_output_retry gh api graphql \
-              -f owner="$owner" \
-              -f repo="$repo" \
-              -F number="$pr" \
-              -f query='
-                query($owner: String!, $repo: String!, $number: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $number) {
-                      reviewThreads(first: 100) {
-                        nodes {
-                          isResolved
-                        }
-                      }
-                    }
-                  }
-                }' \
-              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved == false)] | length'
-          }
-
-          required_checks_passed() {
-            local pr="$1"
-            local attempt
-            local check_error
-            local checks_json
-            local check_status
-            local max_attempts=4
-            local non_passing
-
-            for attempt in $(seq 1 "$max_attempts"); do
-              check_error="$(mktemp)"
-              set +e
-              checks_json="$(gh pr checks "$pr" --required --json name,bucket,state 2>"$check_error")"
-              check_status="$?"
-              set -e
-
-              if [[ "$check_status" -eq 0 ]]; then
-                rm -f "$check_error"
-                break
-              fi
-
-              if [[ "$check_status" -eq 8 ]]; then
-                echo "PR #$pr required checks are still pending."
-                rm -f "$check_error"
-                return 1
-              fi
-
-              echo "PR #$pr required checks could not be read on attempt $attempt/$max_attempts:"
-              cat "$check_error"
-              rm -f "$check_error"
-
-              if [[ "$attempt" -eq "$max_attempts" ]]; then
-                return 1
-              fi
-
-              sleep "$((attempt * 2))"
-            done
-
-            non_passing="$(jq '[.[] | select(.bucket != "pass")] | length' <<<"$checks_json")"
-            if [[ "$non_passing" -ne 0 ]]; then
-              echo "PR #$pr has required checks that are not passing:"
-              jq -r '.[] | select(.bucket != "pass") | "- \(.name): \(.state)"' <<<"$checks_json"
-              return 1
-            fi
-
-            return 0
-          }
-
-          request_review_once() {
-            local pr="$1"
-            local head="$2"
-            local review="$3"
-            local body
-            local comments_json
-            local marker
-            local has_marker
-            marker="<!-- bandscope-pr-review-merge-scheduler:${head} -->"
-
-            if ! comments_json="$(gh_output_retry gh pr view "$pr" --json comments)"; then
-              echo "PR #$pr comments could not be read; skipping scheduler review request for this pass."
-              return 0
-            fi
-            has_marker="$(jq --arg marker "$marker" 'any(.comments[]?; .body | contains($marker))' <<<"$comments_json")"
-            if [[ "$has_marker" == "true" ]]; then
-              echo "PR #$pr already has a scheduler review request for $head."
-              return 0
-            fi
-
-            body="$(printf '%s\n%s\n\n%s\n' \
-              "$marker" \
-              "@coderabbitai review" \
-              "Scheduled PR review/merge pass found zero unresolved review threads, but this head is not approved yet (${review}). Please review this current head so the normal merge gate can decide it.")"
-            if ! gh_output_retry gh pr comment "$pr" --body "$body"; then
-              echo "PR #$pr scheduler review request could not be posted; skipping for this pass."
-            fi
-          }
-
-          prs_json="$(gh_output_retry gh pr list \
-            --base "$DEFAULT_BRANCH" \
-            --state open \
-            --limit "$MAX_PRS" \
-            --json number,title,headRefOid,reviewDecision,mergeStateStatus,isDraft)"
-
-          while IFS= read -r pr_json; do
-            pr="$(jq -r '.number' <<<"$pr_json")"
-            head="$(jq -r '.headRefOid' <<<"$pr_json")"
-            review="$(jq -r '.reviewDecision' <<<"$pr_json")"
-            merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_json")"
-            title="$(jq -r '.title' <<<"$pr_json")"
-
-            echo "Inspecting PR #$pr: $title"
-
-            if ! unresolved="$(unresolved_threads "$pr")"; then
-              echo "PR #$pr review threads could not be read after retries; skipping this pass."
-              continue
-            fi
-            if [[ "$unresolved" -ne 0 ]]; then
-              echo "PR #$pr has $unresolved unresolved review thread(s); leaving it for code fixes."
-              continue
-            fi
-
-            if [[ "$review" != "APPROVED" ]]; then
-              request_review_once "$pr" "$head" "$review"
-              continue
-            fi
-
-            if ! required_checks_passed "$pr"; then
-              continue
-            fi
-
-            if [[ "$merge_state" == "DIRTY" ]]; then
-              echo "PR #$pr has merge conflicts; leaving it for manual conflict resolution."
-              continue
-            fi
-
-            if [[ "$merge_state" == "BEHIND" ]]; then
-              echo "PR #$pr is behind $DEFAULT_BRANCH; updating branch and waiting for fresh checks."
-              gh pr update-branch "$pr" || true
-              continue
-            fi
-
-            echo "PR #$pr is approved, thread-clean, and required checks passed; attempting merge."
-            if ! gh pr merge "$pr" --merge --delete-branch --match-head-commit "$head"; then
-              echo "Direct merge did not complete for PR #$pr; enabling auto-merge when allowed."
-              gh pr merge "$pr" --auto --merge --delete-branch --match-head-commit "$head" || true
-            fi
-          done < <(jq -c '.[] | select(.isDraft | not)' <<<"$prs_json")
+          if [ "$ENABLE_AUTO_MERGE" = "true" ]; then
+            args+=(--enable-auto-merge)
+          else
+            args+=(--no-enable-auto-merge)
+          fi
+          python3 scripts/ci/pr_review_merge_scheduler.py "${args[@]}"

--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -42,8 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: write
-      issues: write
+      contents: read
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}

--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -29,6 +29,9 @@ concurrency:
   group: pr-review-merge-scheduler
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: init.defaultBranch
@@ -38,9 +41,8 @@ jobs:
   scan-pr-queue:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       checks: read
-      contents: write
+      contents: read
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: read
+      contents: write
+      issues: write
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}

--- a/.github/workflows/pr-review-merge-scheduler.yml
+++ b/.github/workflows/pr-review-merge-scheduler.yml
@@ -25,12 +25,12 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-review-merge-scheduler
   cancel-in-progress: false
-
-permissions:
-  contents: read
 
 env:
   GIT_CONFIG_COUNT: "1"
@@ -42,10 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: read
+      contents: write
+      issues: write
       pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN || github.token }}
+      OPENCODE_APPROVE_TOKEN: ${{ secrets.OPENCODE_APPROVE_TOKEN }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
       MAX_PRS: ${{ inputs.max_prs || '100' }}
@@ -57,6 +59,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+
+      - name: Report scheduler token source
+        run: |
+          set -euo pipefail
+          if [ -n "${OPENCODE_APPROVE_TOKEN:-}" ]; then
+            echo "scheduler token source=opencode-approve-token"
+          else
+            echo "scheduler token source=github-token"
+          fi
 
       - name: Self-test scheduler
         run: python3 scripts/ci/pr_review_merge_scheduler.py --self-test

--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+OPEN_PRS_QUERY = """\
+query($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $pageSize, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        isDraft
+        mergeable
+        reviewDecision
+        baseRefName
+        baseRefOid
+        headRefName
+        headRefOid
+        headRepository { nameWithOwner }
+        autoMergeRequest { enabledAt }
+        reviewThreads(first: 100) {
+          nodes { isResolved isOutdated }
+        }
+        reviews(last: 50) {
+          nodes {
+            state
+            body
+            submittedAt
+            author { login }
+            commit { oid }
+          }
+        }
+        statusCheckRollup {
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                name
+                status
+                conclusion
+                checkSuite {
+                  workflowRun {
+                    workflow { name }
+                  }
+                }
+              }
+              ... on StatusContext {
+                context
+                state
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass
+class Decision:
+    pr: int
+    action: str
+    reason: str
+
+
+def run(args: list[str], *, stdin: str | None = None) -> str:
+    process = subprocess.run(args, input=stdin, capture_output=True, text=True)
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({process.returncode}): {' '.join(args)}\n{process.stderr}"
+        )
+    return process.stdout
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    try:
+        owner, name = repo.split("/", 1)
+    except ValueError as exc:
+        raise ValueError(f"repo must be owner/name, got {repo!r}") from exc
+    if not owner or not name:
+        raise ValueError(f"repo must be owner/name, got {repo!r}")
+    return owner, name
+
+
+def gh_graphql(query: str, **fields: str | int) -> dict[str, Any]:
+    cmd = ["gh", "api", "graphql", "-F", "query=@-"]
+    for key, value in fields.items():
+        flag = "-F" if isinstance(value, int) else "-f"
+        cmd.extend([flag, f"{key}={value}"])
+    return json.loads(run(cmd, stdin=query))
+
+
+def fetch_open_prs(repo: str, max_prs: int) -> list[dict[str, Any]]:
+    owner, name = split_repo(repo)
+    prs: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while len(prs) < max_prs:
+        page_size = min(100, max_prs - len(prs))
+        fields: dict[str, str | int] = {
+            "owner": owner,
+            "name": name,
+            "pageSize": page_size,
+        }
+        if cursor:
+            fields["cursor"] = cursor
+        payload = gh_graphql(OPEN_PRS_QUERY, **fields)
+        pr_page = payload["data"]["repository"]["pullRequests"]
+        prs.extend(pr_page.get("nodes") or [])
+        if not pr_page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = pr_page["pageInfo"]["endCursor"]
+
+    return prs
+
+
+def context_nodes(pr: dict[str, Any]) -> list[dict[str, Any]]:
+    rollup = pr.get("statusCheckRollup") or {}
+    contexts = rollup.get("contexts") or {}
+    return contexts.get("nodes") or []
+
+
+def is_opencode_context(node: dict[str, Any]) -> bool:
+    if node.get("__typename") == "CheckRun":
+        workflow = (
+            ((node.get("checkSuite") or {}).get("workflowRun") or {}).get("workflow")
+            or {}
+        )
+        return node.get("name") == "opencode-review" or workflow.get("name") == "OpenCode Review"
+    return node.get("context") == "opencode-review"
+
+
+def opencode_in_progress(pr: dict[str, Any]) -> bool:
+    for node in context_nodes(pr):
+        if not is_opencode_context(node):
+            continue
+        status = (node.get("status") or node.get("state") or "").upper()
+        if status and status not in {"COMPLETED", "SUCCESS", "FAILURE", "ERROR"}:
+            return True
+    return False
+
+
+def unresolved_thread_count(pr: dict[str, Any]) -> int:
+    threads = ((pr.get("reviewThreads") or {}).get("nodes") or [])
+    return sum(1 for thread in threads if not thread.get("isResolved") and not thread.get("isOutdated"))
+
+
+def review_author_login(review: dict[str, Any]) -> str:
+    return ((review.get("author") or {}).get("login") or "").lower()
+
+
+def is_opencode_review(review: dict[str, Any]) -> bool:
+    login = review_author_login(review)
+    body = review.get("body") or ""
+    return login.startswith("opencode-agent") or "opencode" in login or "OpenCode Agent" in body
+
+
+def current_head_review_state(pr: dict[str, Any], state: str) -> bool:
+    head = pr.get("headRefOid")
+    for review in reversed((pr.get("reviews") or {}).get("nodes") or []):
+        if not is_opencode_review(review):
+            continue
+        if (review.get("state") or "").upper() != state:
+            continue
+        commit = (review.get("commit") or {}).get("oid")
+        if commit == head:
+            return True
+    return False
+
+
+def has_current_head_approval(pr: dict[str, Any]) -> bool:
+    return current_head_review_state(pr, "APPROVED")
+
+
+def has_current_head_changes_requested(pr: dict[str, Any]) -> bool:
+    return current_head_review_state(pr, "CHANGES_REQUESTED")
+
+
+def enable_auto_merge(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
+    number = str(pr["number"])
+    head = pr["headRefOid"]
+    if dry_run:
+        return
+    run(["gh", "pr", "merge", number, "--repo", repo, "--auto", "--merge", "--match-head-commit", head])
+
+
+def dispatch_opencode_review(repo: str, workflow: str, pr: dict[str, Any], *, dry_run: bool) -> None:
+    if dry_run:
+        return
+    run(
+        [
+            "gh",
+            "workflow",
+            "run",
+            workflow,
+            "--repo",
+            repo,
+            "--ref",
+            pr["baseRefName"],
+            "-f",
+            f"pr_number={pr['number']}",
+            "-f",
+            f"pr_base_ref={pr['baseRefName']}",
+            "-f",
+            f"pr_base_sha={pr['baseRefOid']}",
+            "-f",
+            f"pr_head_ref={pr['headRefName']}",
+            "-f",
+            f"pr_head_sha={pr['headRefOid']}",
+        ]
+    )
+
+
+def inspect_pr(
+    repo: str,
+    pr: dict[str, Any],
+    *,
+    dry_run: bool,
+    trigger_reviews: bool,
+    enable_auto_merge_flag: bool,
+    workflow: str,
+    base_branch: str,
+) -> Decision:
+    number = pr["number"]
+    head_repo = (pr.get("headRepository") or {}).get("nameWithOwner")
+    base_ref = pr.get("baseRefName")
+
+    if pr.get("isDraft"):
+        return Decision(number, "skip", "draft PR")
+    if base_ref != base_branch:
+        return Decision(number, "skip", f"base branch is {base_ref}; expected {base_branch}")
+    if head_repo != repo:
+        return Decision(number, "skip", f"fork or external head repo: {head_repo}")
+
+    unresolved = unresolved_thread_count(pr)
+    if unresolved:
+        return Decision(number, "block", f"{unresolved} unresolved review thread(s)")
+
+    if has_current_head_changes_requested(pr):
+        return Decision(number, "block", "current-head OpenCode review requested changes")
+
+    if has_current_head_approval(pr):
+        if pr.get("autoMergeRequest"):
+            return Decision(number, "wait", "current head is approved; auto-merge already enabled")
+        if not enable_auto_merge_flag:
+            return Decision(number, "wait", "current head is approved; auto-merge disabled by scheduler inputs")
+        enable_auto_merge(repo, pr, dry_run=dry_run)
+        return Decision(number, "auto_merge", "current head is approved; auto-merge enabled")
+
+    if opencode_in_progress(pr):
+        return Decision(number, "wait", "OpenCode review is already in progress")
+
+    if trigger_reviews:
+        dispatch_opencode_review(repo, workflow, pr, dry_run=dry_run)
+        return Decision(number, "review_dispatch", "current head has no OpenCode approval")
+
+    return Decision(number, "block", "current head has no OpenCode approval")
+
+
+def print_summary(
+    decisions: list[Decision],
+    *,
+    dry_run: bool,
+    base_branch: str,
+    project_flow: str,
+) -> None:
+    counts: dict[str, int] = {}
+    for decision in decisions:
+        counts[decision.action] = counts.get(decision.action, 0) + 1
+        print(f"PR #{decision.pr}: {decision.action}: {decision.reason}")
+    print(
+        json.dumps(
+            {
+                "base_branch": base_branch,
+                "dry_run": dry_run,
+                "inspected": len(decisions),
+                "counts": counts,
+                "project_flow": project_flow,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def self_test() -> None:
+    sample = {
+        "number": 1,
+        "headRefOid": "abc",
+        "isDraft": False,
+        "headRepository": {"nameWithOwner": "owner/repo"},
+        "reviewDecision": "REVIEW_REQUIRED",
+        "reviewThreads": {"nodes": []},
+        "reviews": {
+            "nodes": [
+                {
+                    "state": "APPROVED",
+                    "author": {"login": "opencode-agent"},
+                    "body": "OpenCode Agent approved this head.",
+                    "commit": {"oid": "abc"},
+                }
+            ]
+        },
+        "statusCheckRollup": {"contexts": {"nodes": []}},
+    }
+    assert has_current_head_approval(sample)
+    assert not has_current_head_changes_requested(sample)
+    sample["reviews"]["nodes"].append(
+        {
+            "state": "CHANGES_REQUESTED",
+            "author": {"login": "opencode-agent"},
+            "commit": {"oid": "old"},
+        }
+    )
+    assert not has_current_head_changes_requested(sample)
+    sample["statusCheckRollup"]["contexts"]["nodes"].append(
+        {"__typename": "CheckRun", "name": "opencode-review", "status": "IN_PROGRESS"}
+    )
+    assert opencode_in_progress(sample)
+    print("self-test passed")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--base-branch", default=os.environ.get("DEFAULT_BRANCH", ""))
+    parser.add_argument("--project-flow", default=os.environ.get("PROJECT_FLOW", ""))
+    parser.add_argument("--max-prs", type=int, default=100)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--trigger-reviews", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--enable-auto-merge", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--review-workflow", default="OpenCode Review")
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.self_test:
+        self_test()
+        return 0
+    if not args.repo:
+        raise SystemExit("--repo is required")
+    if not args.base_branch:
+        raise SystemExit("--base-branch is required")
+    if not args.project_flow:
+        raise SystemExit("--project-flow is required")
+    prs = fetch_open_prs(args.repo, args.max_prs)
+    decisions = [
+        inspect_pr(
+            args.repo,
+            pr,
+            dry_run=args.dry_run,
+            trigger_reviews=args.trigger_reviews,
+            enable_auto_merge_flag=args.enable_auto_merge,
+            workflow=args.review_workflow,
+            base_branch=args.base_branch,
+        )
+        for pr in prs
+    ]
+    print_summary(
+        decisions,
+        dry_run=args.dry_run,
+        base_branch=args.base_branch,
+        project_flow=args.project_flow,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: D100,D101,D102,D103
 from __future__ import annotations
 
 import argparse

--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# ruff: noqa: D100,D101,D102,D103
+"""Inspect open pull requests and enable safe OpenCode-gated auto-merge."""
+
 from __future__ import annotations
 
 import argparse
@@ -70,12 +71,16 @@ query($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
 
 @dataclass
 class Decision:
+    """Scheduler action selected for a pull request."""
+
     pr: int
     action: str
     reason: str
 
 
 def run(args: list[str], *, stdin: str | None = None) -> str:
+    """Run a command and return stdout."""
+
     process = subprocess.run(args, input=stdin, capture_output=True, text=True)
     if process.returncode != 0:
         raise RuntimeError(
@@ -85,6 +90,8 @@ def run(args: list[str], *, stdin: str | None = None) -> str:
 
 
 def split_repo(repo: str) -> tuple[str, str]:
+    """Split an owner/name repository string."""
+
     try:
         owner, name = repo.split("/", 1)
     except ValueError as exc:
@@ -95,6 +102,8 @@ def split_repo(repo: str) -> tuple[str, str]:
 
 
 def gh_graphql(query: str, **fields: str | int) -> dict[str, Any]:
+    """Execute a GitHub GraphQL query through gh."""
+
     cmd = ["gh", "api", "graphql", "-F", "query=@-"]
     for key, value in fields.items():
         flag = "-F" if isinstance(value, int) else "-f"
@@ -103,6 +112,8 @@ def gh_graphql(query: str, **fields: str | int) -> dict[str, Any]:
 
 
 def fetch_open_prs(repo: str, max_prs: int) -> list[dict[str, Any]]:
+    """Fetch open pull requests from GitHub."""
+
     owner, name = split_repo(repo)
     prs: list[dict[str, Any]] = []
     cursor: str | None = None
@@ -127,12 +138,16 @@ def fetch_open_prs(repo: str, max_prs: int) -> list[dict[str, Any]]:
 
 
 def context_nodes(pr: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return status context nodes for a pull request."""
+
     rollup = pr.get("statusCheckRollup") or {}
     contexts = rollup.get("contexts") or {}
     return contexts.get("nodes") or []
 
 
 def is_opencode_context(node: dict[str, Any]) -> bool:
+    """Return whether a status node belongs to OpenCode review."""
+
     if node.get("__typename") == "CheckRun":
         workflow = (
             ((node.get("checkSuite") or {}).get("workflowRun") or {}).get("workflow")
@@ -143,6 +158,8 @@ def is_opencode_context(node: dict[str, Any]) -> bool:
 
 
 def opencode_in_progress(pr: dict[str, Any]) -> bool:
+    """Return whether OpenCode review is still running."""
+
     for node in context_nodes(pr):
         if not is_opencode_context(node):
             continue
@@ -153,21 +170,29 @@ def opencode_in_progress(pr: dict[str, Any]) -> bool:
 
 
 def unresolved_thread_count(pr: dict[str, Any]) -> int:
+    """Count active unresolved review threads."""
+
     threads = ((pr.get("reviewThreads") or {}).get("nodes") or [])
     return sum(1 for thread in threads if not thread.get("isResolved") and not thread.get("isOutdated"))
 
 
 def review_author_login(review: dict[str, Any]) -> str:
+    """Return a review author's normalized login."""
+
     return ((review.get("author") or {}).get("login") or "").lower()
 
 
 def is_opencode_review(review: dict[str, Any]) -> bool:
+    """Return whether a review was authored by OpenCode."""
+
     login = review_author_login(review)
     body = review.get("body") or ""
     return login.startswith("opencode-agent") or "opencode" in login or "OpenCode Agent" in body
 
 
 def current_head_review_state(pr: dict[str, Any], state: str) -> bool:
+    """Return whether the current head has a matching OpenCode review state."""
+
     head = pr.get("headRefOid")
     for review in reversed((pr.get("reviews") or {}).get("nodes") or []):
         if not is_opencode_review(review):
@@ -181,14 +206,20 @@ def current_head_review_state(pr: dict[str, Any], state: str) -> bool:
 
 
 def has_current_head_approval(pr: dict[str, Any]) -> bool:
+    """Return whether the current head has OpenCode approval."""
+
     return current_head_review_state(pr, "APPROVED")
 
 
 def has_current_head_changes_requested(pr: dict[str, Any]) -> bool:
+    """Return whether the current head has OpenCode changes requested."""
+
     return current_head_review_state(pr, "CHANGES_REQUESTED")
 
 
 def enable_auto_merge(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
+    """Enable GitHub auto-merge for an approved pull request."""
+
     number = str(pr["number"])
     head = pr["headRefOid"]
     if dry_run:
@@ -197,6 +228,8 @@ def enable_auto_merge(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
 
 
 def dispatch_opencode_review(repo: str, workflow: str, pr: dict[str, Any], *, dry_run: bool) -> None:
+    """Dispatch the OpenCode review workflow for a pull request."""
+
     if dry_run:
         return
     run(
@@ -233,6 +266,8 @@ def inspect_pr(
     workflow: str,
     base_branch: str,
 ) -> Decision:
+    """Inspect a pull request and select the scheduler action."""
+
     number = pr["number"]
     head_repo = (pr.get("headRepository") or {}).get("nameWithOwner")
     base_ref = pr.get("baseRefName")
@@ -276,6 +311,8 @@ def print_summary(
     base_branch: str,
     project_flow: str,
 ) -> None:
+    """Print human-readable and machine-readable scheduler results."""
+
     counts: dict[str, int] = {}
     for decision in decisions:
         counts[decision.action] = counts.get(decision.action, 0) + 1
@@ -295,6 +332,8 @@ def print_summary(
 
 
 def self_test() -> None:
+    """Run scheduler behavior smoke tests."""
+
     sample = {
         "number": 1,
         "headRefOid": "abc",
@@ -332,6 +371,8 @@ def self_test() -> None:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse scheduler command-line arguments."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
     parser.add_argument("--base-branch", default=os.environ.get("DEFAULT_BRANCH", ""))
@@ -346,6 +387,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
+    """Run the PR review merge scheduler."""
+
     args = parse_args(argv)
     if args.self_test:
         self_test()


### PR DESCRIPTION
Replaces the inline merge scheduler with the OpenCode-aware scheduler. It only enables auto-merge for default-branch PRs that have current-head OpenCode approval and no unresolved review threads.\n\nValidation: python3 scripts/ci/pr_review_merge_scheduler.py --self-test