### PR TITLE
⚡ Bolt: [Replace intermediate array allocations in role mapping]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 ## 2025-02-14 - Replace Set with Map.map with for loop
 **Learning:** Using `new Set(array.map(...))` creates an unnecessary intermediate array which wastes memory allocation and garbage collection time, particularly for frequent renders of large transcription arrays.
 **Action:** Replace `array.map()` inside `new Set()` with a `for...of` loop or `.reduce()` to iterate and add elements directly to the Set for O(1) memory and avoiding intermediate array allocations.
+
+## 2025-02-15 - Replace Array.from(map.values()).map with a for...of loop
+**Learning:** Using `Array.from(map.values()).map(...)` creates an unnecessary intermediate array which wastes memory allocation and garbage collection time, particularly for frequently re-rendered components handling large collections.
+**Action:** Use a `for...of` loop over `map.values()` to iterate and push mapped elements directly into the final array for O(1) memory and avoiding intermediate array allocations.

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -130,7 +130,12 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
   }, [song]);
 
   const allRoles = useMemo(() => {
-    return Array.from(roleMap.values()).map(role => ({ id: role.id, name: role.name }));
+    // Performance: Avoid O(N) allocation of intermediate array from Array.from() before mapping
+    const roles: { id: string; name: string }[] = [];
+    for (const role of roleMap.values()) {
+      roles.push({ id: role.id, name: role.name });
+    }
+    return roles;
   }, [roleMap]);
 
   // Performance: use the cached roleMap so activeRoleDetails does not rescan sections and roles on every render.


### PR DESCRIPTION
💡 What: Replaced `Array.from(roleMap.values()).map(...)` with a `for...of` loop inside the `allRoles` `useMemo` block in `Workspace.tsx`.
🎯 Why: Creating an intermediate array just to iterate over it again unnecessarily consumes memory and adds to garbage collection (GC) overhead. This can cause micro-stutters during frequent workspace re-renders.
📊 Impact: Achieves O(1) memory overhead by avoiding the intermediate array allocation, preventing an O(N) allocation step where N is the number of roles.
🔬 Measurement: Verify using the react profiler during role switching, or confirm via tests: `npm run test --workspace=apps/desktop` and `npm run typecheck --workspace=apps/desktop`.

---
*PR created automatically by Jules for task [15376324858449251490](https://jules.google.com/task/15376324858449251490) started by @seonghobae*