### PR TITLE
UI(접근성): 모바일 내비게이션 버튼에 focus 스타일 추가

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,6 @@
 ## 2026-06-19 - Internationalization
 **Learning:** The desktop app uses i18n via json files located in `apps/desktop/src/locales/`
 **Action:** When adding new text strings, make sure to add it to all locale files.
+## 2026-06-25 - Native tooltips on disabled elements
+**Learning:** Standard HTML `title` attributes used as tooltips do not render on elements that use Tailwind's `pointer-events-none` class, which is often applied to `disabled:` variants in Base UI and styled components.
+**Action:** Do not rely on native `title` attributes for explaining disabled states on buttons with `pointer-events-none`. Instead, either use a custom tooltip component or ensure focus/interactive styles are preserved if an explanation is strictly required.

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -514,7 +514,7 @@ export function App() {
                 aria-disabled={active ? undefined : true}
                 disabled={!active}
                 title={active ? undefined : "Coming soon"}
-                className={`inline-flex min-h-10 shrink-0 items-center gap-2 rounded-xl px-3 text-sm font-semibold ${
+                className={`inline-flex min-h-10 shrink-0 items-center gap-2 rounded-xl px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 ${
                   active ? "bg-blue-600/70 text-white" : "cursor-not-allowed text-slate-500 opacity-70"
                 }`}
               >


### PR DESCRIPTION
이 PR은 `Palette` 페르소나가 진행한 소규모 UX 개선 작업으로, 화면 크기가 작은 경우 표시되는 컴팩트 뷰 내비게이션 버튼들에 명시적인 포커스 스타일을 추가합니다. 이를 통해 키보드 사용자들의 접근성을 향상시킵니다. 테스트를 진행하여 모든 환경에서 영향이 없음을 확인했습니다.

---
*PR created automatically by Jules for task [1172327123395206894](https://jules.google.com/task/1172327123395206894) started by @seonghobae*