### PR TITLE
Gate stale approvals after bot branch updates

### DIFF
--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -33,6 +33,15 @@ query($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
         headRefOid
         headRepository { nameWithOwner }
         autoMergeRequest { enabledAt }
+        commits(last: 1) {
+          nodes {
+            commit {
+              oid
+              authoredDate
+              committedDate
+            }
+          }
+        }
         reviewThreads(first: 100) {
           nodes { isResolved isOutdated }
         }
@@ -91,7 +100,7 @@ def contract_decision(decision: Decision) -> str:
     """Map scheduler actions into the bounded PR decision contract."""
     if decision.action == "update_branch":
         return "UPDATE_BRANCH"
-    if decision.action in {"wait", "security_dispatch", "review_dispatch", "action_error"}:
+    if decision.action in {"wait", "security_dispatch", "review_dispatch", "disable_auto_merge", "action_error"}:
         return "WAIT"
     if decision.action in {"skip", "auto_merge"}:
         return "NO_ACTION"
@@ -183,6 +192,17 @@ def decision_guidance(decision: Decision) -> dict[str, Any] | None:
                 "OpenCode approval on that exact new head",
                 "same-head Strix evidence",
                 "required GitHub Checks success",
+                "zero active unresolved review threads",
+            ],
+        }
+    if decision.action == "disable_auto_merge":
+        return {
+            "type": "fresh_head_review_required",
+            "summary": "Auto-merge was disabled because the PR needs fresh same-head review evidence before it can be merged.",
+            "next_required_evidence": [
+                "OpenCode approval submitted after the current head commit was created",
+                "required GitHub Checks success on the current head",
+                "same-head Strix evidence",
                 "zero active unresolved review threads",
             ],
         }
@@ -301,6 +321,57 @@ def parse_github_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def head_commit_datetime(pr: dict[str, Any]) -> datetime | None:
+    """Return the current PR head commit time from the GraphQL commit edge."""
+    commits = ((pr.get("commits") or {}).get("nodes") or [])
+    if not commits:
+        return None
+    commit = (commits[-1].get("commit") or {})
+    return parse_github_datetime(commit.get("committedDate"))
+
+
+def review_submitted_datetime(review: dict[str, Any]) -> datetime | None:
+    """Return the review submission time as an aware UTC datetime."""
+    return parse_github_datetime(review.get("submittedAt"))
+
+
+def review_matches_current_head(review: dict[str, Any], pr: dict[str, Any]) -> bool:
+    """Return whether a review is valid evidence for the current head commit."""
+    head = pr.get("headRefOid")
+    commit = (review.get("commit") or {}).get("oid")
+    if commit != head:
+        return False
+    head_time = head_commit_datetime(pr)
+    if not head_time:
+        return True
+    submitted_at = review_submitted_datetime(review)
+    return bool(submitted_at and submitted_at >= head_time)
+
+
+def stale_current_head_review_reason(pr: dict[str, Any]) -> str | None:
+    """Explain why a same-commit OpenCode review is stale for the current head."""
+    head = pr.get("headRefOid")
+    head_time = head_commit_datetime(pr)
+    if not head or not head_time:
+        return None
+    for review in reversed((pr.get("reviews") or {}).get("nodes") or []):
+        if not is_opencode_review(review):
+            continue
+        commit = (review.get("commit") or {}).get("oid")
+        if commit != head:
+            continue
+        submitted_at = review_submitted_datetime(review)
+        if not submitted_at:
+            return "OpenCode review has no submission timestamp for the current head"
+        if submitted_at < head_time:
+            return (
+                "OpenCode review predates the current head commit "
+                f"({submitted_at.isoformat()} < {head_time.isoformat()})"
+            )
+        return None
+    return None
+
+
 def running_check_state(node: dict[str, Any]) -> str:
     """Return running, complete, or absent for a check/status context."""
     status = (node.get("status") or node.get("state") or "").upper()
@@ -375,12 +446,10 @@ def is_opencode_review(review: dict[str, Any]) -> bool:
 
 def current_head_review_state(pr: dict[str, Any], state: str) -> bool:
     """Return whether OpenCode's latest current-head review has the target state."""
-    head = pr.get("headRefOid")
     for review in reversed((pr.get("reviews") or {}).get("nodes") or []):
         if not is_opencode_review(review):
             continue
-        commit = (review.get("commit") or {}).get("oid")
-        if commit != head:
+        if not review_matches_current_head(review, pr):
             continue
         return (review.get("state") or "").upper() == state
     return False
@@ -430,6 +499,14 @@ def enable_auto_merge(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
     if dry_run:
         return
     run(["gh", "pr", "merge", number, "--repo", repo, "--auto", "--merge", "--match-head-commit", head])
+
+
+def disable_auto_merge(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
+    """Disable auto-merge when the current head no longer has fresh review evidence."""
+    number = str(pr["number"])
+    if dry_run:
+        return
+    run(["gh", "pr", "merge", number, "--repo", repo, "--disable-auto"])
 
 
 def update_branch(repo: str, pr: dict[str, Any], *, dry_run: bool) -> None:
@@ -555,6 +632,14 @@ def inspect_pr(
         return Decision(number, "block", "current-head OpenCode review requested changes")
 
     current_head_approved = has_current_head_approval(pr)
+    stale_review_reason = stale_current_head_review_reason(pr)
+    if stale_review_reason and pr.get("autoMergeRequest"):
+        disable_auto_merge(repo, pr, dry_run=dry_run)
+        return Decision(
+            number,
+            "disable_auto_merge",
+            f"auto-merge disabled; {stale_review_reason}; wait for a fresh same-head OpenCode review",
+        )
     if current_head_approved:
         failed_checks = failed_status_checks(pr)
         if failed_checks:
@@ -838,7 +923,19 @@ def self_test() -> None:
         "mergeStateStatus": "CLEAN",
         "isDraft": False,
         "headRepository": {"nameWithOwner": "owner/repo"},
+        "autoMergeRequest": None,
         "reviewDecision": "REVIEW_REQUIRED",
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "oid": "abc",
+                        "authoredDate": "2026-01-01T00:00:00Z",
+                        "committedDate": "2026-01-01T00:00:00Z",
+                    }
+                }
+            ]
+        },
         "reviewThreads": {"nodes": []},
         "reviews": {
             "nodes": [
@@ -846,6 +943,7 @@ def self_test() -> None:
                     "state": "APPROVED",
                     "author": {"login": "opencode-agent"},
                     "body": "OpenCode Agent approved this head.",
+                    "submittedAt": "2026-01-01T00:01:00Z",
                     "commit": {"oid": "abc"},
                 }
             ]
@@ -866,6 +964,24 @@ def self_test() -> None:
         base_branch="main",
     )
     assert decision.action == "auto_merge"
+    sample["autoMergeRequest"] = {"enabledAt": "2026-01-01T00:02:00Z"}
+    sample["reviews"]["nodes"][0]["submittedAt"] = "2025-12-31T23:59:59Z"
+    assert not has_current_head_approval(sample)
+    decision = inspect_pr(
+        "owner/repo",
+        sample,
+        dry_run=True,
+        trigger_reviews=True,
+        enable_auto_merge_flag=True,
+        update_branches=True,
+        workflow="OpenCode Review",
+        security_workflow="Strix Security Scan",
+        base_branch="main",
+    )
+    assert decision.action == "disable_auto_merge"
+    assert "predates the current head commit" in decision.reason
+    sample["autoMergeRequest"] = None
+    sample["reviews"]["nodes"][0]["submittedAt"] = "2026-01-01T00:01:00Z"
     sample["statusCheckRollup"]["contexts"]["nodes"] = [
         {"__typename": "CheckRun", "name": "strix", "status": "COMPLETED", "conclusion": "FAILURE"}
     ]
@@ -888,6 +1004,7 @@ def self_test() -> None:
             "state": "APPROVED",
             "author": {"login": "not-opencode-agent"},
             "body": "OpenCode Agent approved this head.",
+            "submittedAt": "2026-01-01T00:01:00Z",
             "commit": {"oid": "abc"},
         }
     )
@@ -898,6 +1015,7 @@ def self_test() -> None:
         {
             "state": "CHANGES_REQUESTED",
             "author": {"login": "opencode-agent"},
+            "submittedAt": "2026-01-01T00:01:00Z",
             "commit": {"oid": "old"},
         }
     )
@@ -912,6 +1030,7 @@ def self_test() -> None:
         {
             "state": "APPROVED",
             "author": {"login": "opencode-agent"},
+            "submittedAt": "2026-01-01T00:01:00Z",
             "commit": {"oid": "old"},
         }
     ]
@@ -1027,6 +1146,7 @@ def self_test() -> None:
     assert contract_decision(Decision(1, "update_branch", "ok")) == "UPDATE_BRANCH"
     assert contract_decision(Decision(1, "wait", "ok")) == "WAIT"
     assert contract_decision(Decision(1, "action_error", "ok")) == "WAIT"
+    assert contract_decision(Decision(1, "disable_auto_merge", "ok")) == "WAIT"
     assert contract_decision(Decision(1, "auto_merge", "ok")) == "NO_ACTION"
     assert contract_decision(Decision(1, "skip", "ok")) == "NO_ACTION"
     assert (
@@ -1038,6 +1158,9 @@ def self_test() -> None:
     assert update_guidance
     assert update_guidance["actor"] == "github-actions[bot]"
     assert update_guidance["head_guard"] == "expected_head_sha"
+    disable_guidance = decision_guidance(Decision(1, "disable_auto_merge", "ok"))
+    assert disable_guidance
+    assert disable_guidance["type"] == "fresh_head_review_required"
     assert decision_guidance(Decision(1, "wait", "ok")) is None
     payload = decision_payload(
         [Decision(1, "update_branch", "ok")],

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -4994,6 +4994,12 @@ def test_pr_review_merge_scheduler_uses_github_actions_token() -> None:
 
     assert "def validate_gh_host" in scheduler
     assert "unsupported GH_HOST" in scheduler
+    assert "commits(last: 1)" in scheduler
+    assert "committedDate" in scheduler
+    assert "def stale_current_head_review_reason" in scheduler
+    assert "review_submitted_datetime(review)" in scheduler
+    assert "def disable_auto_merge" in scheduler
+    assert '"gh", "pr", "merge", number, "--repo", repo, "--disable-auto"' in scheduler
     assert "if is_opencode_context(node):" in scheduler
     assert '"strix security scan" | "strix security scan/"*' in collector
 


### PR DESCRIPTION
## Summary
- Require OpenCode reviews to be submitted after the current PR head commit timestamp before they count as same-head approval.
- Disable auto-merge when a bot-updated branch still shows an older approval for the new head.
- Keep conflicted PRs in WAIT with concrete repair commands instead of retrying `update-branch`.

## Why
The scheduler successfully updated outdated bandscope PRs with the workflow `GITHUB_TOKEN`, producing `github-actions[bot]` merge commits. GitHub still reported prior OpenCode approval on those PRs, but the approval timestamp predated the new bot merge commit. This change prevents the scheduler from treating those stale approvals as merge evidence.

## Live dry-run evidence
Against current bandscope queue after the bot updates:

```json
{
  "counts": {"block": 77, "wait": 1},
  "inspected": 78,
  "p439": {"action": "block", "contract_decision": "WAIT", "pr": 439, "reason": "current head has no OpenCode approval"},
  "p451": {"action": "block", "contract_decision": "WAIT", "pr": 451, "reason": "current head has no OpenCode approval"}
}
```

## Tests
- `python3 scripts/ci/pr_review_merge_scheduler.py --self-test`
- `pytest -q services/analysis-engine/tests/test_supply_chain_policy.py::test_pr_review_merge_scheduler_uses_github_actions_token`
- `actionlint -shellcheck= -pyflakes= .github/workflows/pr-review-merge-scheduler.yml .github/workflows/opencode-review.yml`
- `bash -n scripts/ci/collect_failed_check_evidence.sh scripts/ci/emit_opencode_failed_check_fallback_findings.sh scripts/ci/validate_opencode_failed_check_review.sh scripts/ci/opencode_review_approve_gate.sh`
- `python3 -m py_compile scripts/ci/pr_review_merge_scheduler.py`
- `python3 scripts/ci/pr_review_merge_scheduler.py --repo ContextualWisdomLab/bandscope --base-branch develop --project-flow git-flow --dry-run --max-prs 120 --no-trigger-reviews --no-enable-auto-merge --update-branches --stale-opencode-minutes 45`
