### PR TITLE
ci: trust same-head OpenCode review OID

### DIFF
--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -322,55 +322,11 @@ def parse_github_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def head_commit_datetime(pr: dict[str, Any]) -> datetime | None:
-    """Return the current PR head commit time from the GraphQL commit edge."""
-    commits = ((pr.get("commits") or {}).get("nodes") or [])
-    if not commits:
-        return None
-    commit = (commits[-1].get("commit") or {})
-    return parse_github_datetime(commit.get("committedDate"))
-
-
-def review_submitted_datetime(review: dict[str, Any]) -> datetime | None:
-    """Return the review submission time as an aware UTC datetime."""
-    return parse_github_datetime(review.get("submittedAt"))
-
-
 def review_matches_current_head(review: dict[str, Any], pr: dict[str, Any]) -> bool:
     """Return whether a review is valid evidence for the current head commit."""
     head = pr.get("headRefOid")
     commit = (review.get("commit") or {}).get("oid")
-    if commit != head:
-        return False
-    head_time = head_commit_datetime(pr)
-    if not head_time:
-        return True
-    submitted_at = review_submitted_datetime(review)
-    return bool(submitted_at and submitted_at > head_time)
-
-
-def stale_current_head_review_reason(pr: dict[str, Any]) -> str | None:
-    """Explain why a same-commit OpenCode review is stale for the current head."""
-    head = pr.get("headRefOid")
-    head_time = head_commit_datetime(pr)
-    if not head or not head_time:
-        return None
-    for review in reversed((pr.get("reviews") or {}).get("nodes") or []):
-        if not is_opencode_review(review):
-            continue
-        commit = (review.get("commit") or {}).get("oid")
-        if commit != head:
-            continue
-        submitted_at = review_submitted_datetime(review)
-        if not submitted_at:
-            return "OpenCode review has no submission timestamp for the current head"
-        if submitted_at <= head_time:
-            return (
-                "OpenCode review does not postdate the current head commit "
-                f"({submitted_at.isoformat()} <= {head_time.isoformat()})"
-            )
-        return None
-    return None
+    return bool(head and commit == head)
 
 
 def running_check_state(node: dict[str, Any]) -> str:
@@ -666,14 +622,6 @@ def inspect_pr(
         return Decision(number, "block", "current-head OpenCode review requested changes")
 
     current_head_approved = has_current_head_approval(pr)
-    stale_review_reason = stale_current_head_review_reason(pr)
-    if stale_review_reason and pr.get("autoMergeRequest"):
-        disable_auto_merge(repo, pr, dry_run=dry_run)
-        return Decision(
-            number,
-            "disable_auto_merge",
-            f"auto-merge disabled; {stale_review_reason}; wait for a fresh same-head OpenCode review",
-        )
     if current_head_approved:
         failed_checks = failed_status_checks(pr)
         if failed_checks:
@@ -985,8 +933,8 @@ def self_test() -> None:
                 {
                     "commit": {
                         "oid": "abc",
-                        "authoredDate": "2026-01-01T00:00:00Z",
-                        "committedDate": "2026-01-01T00:00:00Z",
+                        "authoredDate": "2026-06-25T16:38:22Z",
+                        "committedDate": "2026-06-25T16:38:22Z",
                     }
                 }
             ]
@@ -998,7 +946,7 @@ def self_test() -> None:
                     "state": "APPROVED",
                     "author": {"login": "opencode-agent"},
                     "body": "OpenCode Agent approved this head.",
-                    "submittedAt": "2026-01-01T00:01:00Z",
+                    "submittedAt": "2026-06-25T15:42:19Z",
                     "commit": {"oid": "abc"},
                 }
             ]
@@ -1020,8 +968,7 @@ def self_test() -> None:
     )
     assert decision.action == "auto_merge"
     sample["autoMergeRequest"] = {"enabledAt": "2026-01-01T00:02:00Z"}
-    sample["reviews"]["nodes"][0]["submittedAt"] = "2025-12-31T23:59:59Z"
-    assert not has_current_head_approval(sample)
+    assert has_current_head_approval(sample)
     decision = inspect_pr(
         "owner/repo",
         sample,
@@ -1033,24 +980,8 @@ def self_test() -> None:
         security_workflow="Strix Security Scan",
         base_branch="main",
     )
-    assert decision.action == "disable_auto_merge"
-    assert "does not postdate the current head commit" in decision.reason
-    sample["reviews"]["nodes"][0]["submittedAt"] = "2026-01-01T00:00:00Z"
-    assert not has_current_head_approval(sample)
-    decision = inspect_pr(
-        "owner/repo",
-        sample,
-        dry_run=True,
-        trigger_reviews=True,
-        enable_auto_merge_flag=True,
-        update_branches=True,
-        workflow="OpenCode Review",
-        security_workflow="Strix Security Scan",
-        base_branch="main",
-    )
-    assert decision.action == "disable_auto_merge"
-    assert "<=" in decision.reason
-    sample["reviews"]["nodes"][0]["submittedAt"] = "2026-01-01T00:01:00Z"
+    assert decision.action == "wait"
+    assert decision.reason == "current head is approved; auto-merge already enabled"
     sample["statusCheckRollup"]["contexts"]["nodes"] = [
         {"__typename": "CheckRun", "name": "strix", "status": "COMPLETED", "conclusion": "FAILURE"}
     ]

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -5016,11 +5016,13 @@ def test_pr_review_merge_scheduler_uses_github_actions_token() -> None:
     assert "unsupported GH_HOST" in scheduler
     assert "commits(last: 1)" in scheduler
     assert "committedDate" in scheduler
-    assert "def stale_current_head_review_reason" in scheduler
-    assert "review_submitted_datetime(review)" in scheduler
-    assert "submitted_at > head_time" in scheduler
-    assert "submitted_at <= head_time" in scheduler
-    assert "does not postdate the current head commit" in scheduler
+    assert "def review_matches_current_head" in scheduler
+    assert "return bool(head and commit == head)" in scheduler
+    assert "def stale_current_head_review_reason" not in scheduler
+    assert "review_submitted_datetime(review)" not in scheduler
+    assert "submitted_at > head_time" not in scheduler
+    assert "submitted_at <= head_time" not in scheduler
+    assert "does not postdate the current head commit" not in scheduler
     assert "def disable_auto_merge" in scheduler
     assert '"gh", "pr", "merge", number, "--repo", repo, "--disable-auto"' in scheduler
     assert "if is_opencode_context(node):" in scheduler


### PR DESCRIPTION
## Summary
- Treat an OpenCode review attached to the exact PR head commit OID as current-head approval.
- Remove the committedDate/submittedAt ordering check that caused false negatives when Git commit metadata had a later timestamp.
- Keep old-head reviews blocked by OID mismatch and keep conflict PRs on the conflict repair guide path.

## Evidence
- Live PRs such as #451 and #446 had `review.commit.oid == headRefOid`, but the scheduler blocked them as lacking current-head approval because committedDate was later than submittedAt.
- Dry-run after this change reports 11 update-branch candidates: #451, #448, #446, #444, #443, #442, #441, #440, #439, #400, and #387.

## Validation
- `python3 scripts/ci/pr_review_merge_scheduler.py --self-test`
- `python3 -m py_compile scripts/ci/pr_review_merge_scheduler.py`
- `python3 scripts/ci/pr_review_merge_scheduler.py --repo ContextualWisdomLab/bandscope --base-branch develop --project-flow git-flow --dry-run --no-trigger-reviews --enable-auto-merge --update-branches --max-prs 100`
- `git diff --check`