### PR TITLE
ci: refresh PR mergeability before queue decisions

### DIFF
--- a/scripts/ci/pr_review_merge_scheduler.py
+++ b/scripts/ci/pr_review_merge_scheduler.py
@@ -85,6 +85,17 @@ query($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
 OPEN_PRS_PAGE_SIZE = 25
 DEFAULT_STALE_OPENCODE_MINUTES = 45
 RUNNING_CHECK_STATES = {"PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED"}
+REST_MERGEABLE_STATE_MAP = {
+    "behind": "BEHIND",
+    "blocked": "BLOCKED",
+    "clean": "CLEAN",
+    "dirty": "DIRTY",
+    "draft": "DRAFT",
+    "has_hooks": "HAS_HOOKS",
+    "unknown": "UNKNOWN",
+    "unstable": "UNSTABLE",
+}
+REST_MERGEABLE_STATES = set(REST_MERGEABLE_STATE_MAP.values())
 
 
 @dataclass
@@ -274,7 +285,42 @@ def fetch_open_prs(repo: str, max_prs: int) -> list[dict[str, Any]]:
             break
         cursor = pr_page["pageInfo"]["endCursor"]
 
+    enrich_rest_mergeable_states(repo, prs)
     return prs
+
+
+def fetch_rest_mergeable_state(repo: str, number: int) -> str:
+    """Fetch and normalize GitHub REST mergeable_state for one pull request."""
+    raw_state = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{number}",
+            "--jq",
+            ".mergeable_state // \"\"",
+        ]
+    ).strip()
+    return REST_MERGEABLE_STATE_MAP.get(raw_state.lower(), raw_state.upper())
+
+
+def enrich_rest_mergeable_states(repo: str, prs: list[dict[str, Any]]) -> None:
+    """Attach REST mergeability evidence to GraphQL pull request payloads."""
+    for pr in prs:
+        try:
+            pr["restMergeableState"] = fetch_rest_mergeable_state(repo, int(pr["number"]))
+        except RuntimeError as exc:
+            pr["restMergeableStateError"] = bounded_error_summary(str(exc))
+
+
+def effective_merge_state(pr: dict[str, Any]) -> str:
+    """Return the safest merge state from GraphQL plus REST mergeability evidence."""
+    graph_state = (pr.get("mergeStateStatus") or "").upper()
+    rest_state = (pr.get("restMergeableState") or "").upper()
+    if rest_state in REST_MERGEABLE_STATES:
+        return rest_state
+    if graph_state in {"BEHIND", "DIRTY", "CONFLICTING", "UNKNOWN"}:
+        return graph_state
+    return rest_state or graph_state
 
 
 def context_nodes(pr: dict[str, Any]) -> list[dict[str, Any]]:
@@ -589,7 +635,17 @@ def inspect_pr(
     if head_repo != repo:
         return Decision(number, "skip", f"fork or external head repo: {head_repo}")
 
-    merge_state = (pr.get("mergeStateStatus") or "").upper()
+    merge_state = effective_merge_state(pr)
+    if merge_state == "UNKNOWN":
+        if pr.get("autoMergeRequest"):
+            return disable_auto_merge_decision(
+                repo,
+                pr,
+                dry_run=dry_run,
+                reason="mergeability is still being calculated; wait for GitHub mergeability evidence before re-enabling auto-merge",
+            )
+        return Decision(number, "wait", "mergeability is still being calculated")
+
     if merge_state in {"DIRTY", "CONFLICTING"}:
         if pr.get("autoMergeRequest"):
             return disable_auto_merge_decision(
@@ -924,6 +980,7 @@ def self_test() -> None:
         "baseRefOid": "base",
         "headRefName": "feature",
         "mergeStateStatus": "CLEAN",
+        "restMergeableState": "CLEAN",
         "isDraft": False,
         "headRepository": {"nameWithOwner": "owner/repo"},
         "autoMergeRequest": None,
@@ -967,6 +1024,50 @@ def self_test() -> None:
         base_branch="main",
     )
     assert decision.action == "auto_merge"
+    sample["restMergeableState"] = "BEHIND"
+    decision = inspect_pr(
+        "owner/repo",
+        sample,
+        dry_run=True,
+        trigger_reviews=True,
+        enable_auto_merge_flag=True,
+        update_branches=True,
+        workflow="OpenCode Review",
+        security_workflow="Strix Security Scan",
+        base_branch="main",
+    )
+    assert decision.action == "update_branch"
+    sample["restMergeableState"] = "DIRTY"
+    sample["autoMergeRequest"] = {"enabledAt": "2026-01-01T00:02:00Z"}
+    decision = inspect_pr(
+        "owner/repo",
+        sample,
+        dry_run=True,
+        trigger_reviews=True,
+        enable_auto_merge_flag=True,
+        update_branches=True,
+        workflow="OpenCode Review",
+        security_workflow="Strix Security Scan",
+        base_branch="main",
+    )
+    assert decision.action == "disable_auto_merge"
+    assert "merge conflict: DIRTY" in decision.reason
+    sample["restMergeableState"] = "UNKNOWN"
+    sample["autoMergeRequest"] = None
+    decision = inspect_pr(
+        "owner/repo",
+        sample,
+        dry_run=True,
+        trigger_reviews=True,
+        enable_auto_merge_flag=True,
+        update_branches=True,
+        workflow="OpenCode Review",
+        security_workflow="Strix Security Scan",
+        base_branch="main",
+    )
+    assert decision.action == "wait"
+    assert "mergeability is still being calculated" in decision.reason
+    sample["restMergeableState"] = "CLEAN"
     sample["autoMergeRequest"] = {"enabledAt": "2026-01-01T00:02:00Z"}
     assert has_current_head_approval(sample)
     decision = inspect_pr(
@@ -1121,6 +1222,7 @@ def self_test() -> None:
     assert opencode_in_progress(sample)
     sample["statusCheckRollup"]["contexts"]["nodes"] = []
     sample["mergeStateStatus"] = "BEHIND"
+    sample["restMergeableState"] = ""
     sample["reviews"]["nodes"] = [
         {
             "state": "APPROVED",

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -5016,6 +5016,11 @@ def test_pr_review_merge_scheduler_uses_github_actions_token() -> None:
     assert "unsupported GH_HOST" in scheduler
     assert "commits(last: 1)" in scheduler
     assert "committedDate" in scheduler
+    assert "def fetch_rest_mergeable_state" in scheduler
+    assert "mergeable_state" in scheduler
+    assert "def effective_merge_state" in scheduler
+    assert "restMergeableState" in scheduler
+    assert "restMergeableStateError" in scheduler
     assert "def review_matches_current_head" in scheduler
     assert "return bool(head and commit == head)" in scheduler
     assert "def stale_current_head_review_reason" not in scheduler


### PR DESCRIPTION
## Summary
- Refresh each open PR with REST `mergeable_state` before deciding scheduler actions.
- Prefer REST `dirty`, `behind`, and `unknown` states over potentially stale GraphQL `mergeStateStatus`.
- Prevent stale `CLEAN` readings from enabling auto-merge on conflicted PRs, and route stale/behind approved PRs into `update_branch` with the workflow `GITHUB_TOKEN` / `github-actions[bot]` path.

## Evidence
- Before this change, scheduler run 28189853037 enabled auto-merge on PR #450 even though REST now reports `mergeable_state=dirty`, and left PR #451 `BEHIND` with auto-merge enabled.
- Local dry-run after this change classifies PR #450 as `disable_auto_merge` with concrete conflict repair guidance.
- Local dry-run after this change classifies PR #451 and other approved behind PRs as `update_branch` with `github-actions[bot]` guidance.

## Verification
- `python3 scripts/ci/pr_review_merge_scheduler.py --self-test`
- `python3 -m py_compile scripts/ci/pr_review_merge_scheduler.py`
- `pytest -q services/analysis-engine/tests/test_supply_chain_policy.py`
- `git diff --check`
- `python3 scripts/ci/pr_review_merge_scheduler.py --repo ContextualWisdomLab/bandscope --base-branch develop --project-flow git-flow --max-prs 100 --dry-run --no-trigger-reviews --enable-auto-merge --update-branches --stale-opencode-minutes 45`