### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix runtime error information leakage in stem separation worker

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-10-25 - Prevent information leakage from uncaught exceptions
+**Vulnerability:** In Python backend tasks (like stem separation workers), a general `except Exception as error` block leaked the raw stack trace or file path contents into the user-facing IPC `runtime_error` message string by calling `str(error)` directly.
+**Learning:** Backend worker processes often fail on arbitrary external exceptions that can carry verbose inner details. Leaking these violates the 'Fail securely' rule.
+**Prevention:** Replace broad exception casting (like `str(error)`) with generalized static strings (e.g., 'An unexpected error occurred...'). Ensure all explicitly caught errors are intentionally formatted for public reporting, rather than directly coercing exception bodies.

--- a/services/analysis-engine/src/bandscope_analysis/api.py
+++ b/services/analysis-engine/src/bandscope_analysis/api.py
@@ -840,8 +840,8 @@ def _stem_separation_worker(
         result_queue.put(("value_error", str(error)))
     except RuntimeError as error:
         result_queue.put(("runtime_error", str(error)))
-    except Exception as error:
-        result_queue.put(("runtime_error", str(error)))
+    except Exception:
+        result_queue.put(("runtime_error", "An unexpected error occurred during stem separation."))
 
 
 def _multiprocessing_context() -> mp.context.BaseContext:

--- a/services/analysis-engine/tests/test_api.py
+++ b/services/analysis-engine/tests/test_api.py
@@ -848,18 +848,22 @@ def test_stem_separation_worker_maps_safe_error_kinds() -> None:
             self.items.append(item)
 
     cases = [
-        (FileNotFoundError("missing"), "file_not_found"),
-        (ValueError("bad media"), "value_error"),
-        (RuntimeError("oom"), "runtime_error"),
-        (Exception("unexpected"), "runtime_error"),
+        (FileNotFoundError("missing"), "file_not_found", "missing"),
+        (ValueError("bad media"), "value_error", "bad media"),
+        (RuntimeError("oom"), "runtime_error", "oom"),
+        (
+            Exception("unexpected"),
+            "runtime_error",
+            "An unexpected error occurred during stem separation.",
+        ),
     ]
 
-    for error, expected_kind in cases:
+    for error, expected_kind, expected_msg in cases:
         fake_queue = FakeQueue()
         with patch("bandscope_analysis.api.AudioStemSeparator") as separator_class:
             separator_class.return_value.separate.side_effect = error
             _stem_separation_worker("/tmp/audio.wav", fake_queue)
-        assert fake_queue.items == [(expected_kind, str(error))]
+        assert fake_queue.items == [(expected_kind, expected_msg)]
 
     fake_queue = FakeQueue()
     with patch("bandscope_analysis.api.AudioStemSeparator") as separator_class:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `bandscope_analysis.api` 모듈의 `_stem_separation_worker`에서 발생한 예외를 처리할 때, `str(error)`를 그대로 사용자에게 반환하여 내부 스택 트레이스나 파일 시스템 경로 같은 민감한 정보가 노출될 수 있는 위험이 있었습니다.
🎯 **Impact:** 악의적인 사용자가 이러한 에러 메시지를 통해 내부 시스템 구조와 경로 정보를 수집하여 다른 공격에 활용할 수 있습니다.
🔧 **Fix:** 예상치 못한 포괄적 Exception이 발생할 경우 예외 객체의 메시지를 노출하지 않고, "An unexpected error occurred during stem separation."과 같은 정적인 일반 에러 메시지를 반환하도록 수정했습니다.
✅ **Verification:** 테스트 코드 `test_stem_separation_worker_maps_safe_error_kinds`를 업데이트하여 이 수정 사항이 예상대로 동작하는지 확인하였고 전체 테스트를 통과했습니다.

---
*PR created automatically by Jules for task [3480032664147161573](https://jules.google.com/task/3480032664147161573) started by @seonghobae*