### PR TITLE
🎨 Palette: [UX improvement] 비활성화된 아이콘 버튼의 툴팁 및 키보드 접근성 개선

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,12 +9,19 @@
 ## 2026-06-13 - Added screen reader text for tooltip divs
 **Learning:** When using `title` attributes on non-interactive elements like icon-only `div`s for tooltips, screen readers might not announce them properly because they aren't focusable. The visual tooltip is not enough for accessibility.
 **Action:** Always add a visually hidden `<span className="sr-only">[Tooltip Text]</span>` inside non-interactive elements that rely on a `title` attribute so that screen readers have text content to announce.
+
 ## 2026-06-18 - Added keyboard accessibility to scrollable regions
 **Learning:** Horizontally scrollable regions (like the `SectionRoadmap` component) are not accessible to keyboard-only users unless they can receive focus. Keyboard users must be able to focus the container to scroll its content using arrow keys.
 **Action:** For proper keyboard accessibility in custom scrollable regions, always include `tabIndex={0}`, an appropriate `aria-label`, `role="region"`, and explicit focus visible styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300`).
+
 ## 2026-06-19 - Internationalization
 **Learning:** The desktop app uses i18n via json files located in `apps/desktop/src/locales/`
 **Action:** When adding new text strings, make sure to add it to all locale files.
+
 ## 2026-06-25 - Native tooltips on disabled elements
 **Learning:** Standard HTML `title` attributes used as tooltips do not render on elements that use Tailwind's `pointer-events-none` class, which is often applied to `disabled:` variants in Base UI and styled components.
 **Action:** Do not rely on native `title` attributes for explaining disabled states on buttons with `pointer-events-none`. Instead, either use a custom tooltip component or ensure focus/interactive styles are preserved if an explanation is strictly required.
+
+## 2024-06-29 - 비활성화된 네이티브 버튼의 툴팁 차단
+**Learning:** 네이티브 `<button>` 요소에 `disabled` 속성을 사용하면 마우스 호버 이벤트를 포함한 포인터 이벤트가 완전히 차단되어 표준 HTML `title` 속성이 툴팁으로 표시되지 않으며, 키보드 탭 순서(tab order)에서도 제외됩니다.
+**Action:** "출시 예정" 등 설명 툴팁이 필요한 비활성화된 액션 버튼의 경우, `title`을 버튼에 직접 붙이는 대신 포커스 가능한 `span` (`<span tabIndex={0} title={...} role="button" aria-disabled="true">`)으로 버튼을 감싸서 시각적 및 스크린 리더 접근성을 모두 보장해야 합니다.

--- a/apps/desktop/src/App.test.tsx.orig
+++ b/apps/desktop/src/App.test.tsx.orig
@@ -1358,9 +1358,8 @@ describe("App", () => {
     });
   });
 
-
   it("renders disabled Settings and Help buttons as focusable spans for accessibility", () => {
-    render(<App />);
+    renderApp();
     const settingsSpan = screen.getByTitle("Settings coming soon");
     expect(settingsSpan).toHaveAttribute("tabIndex", "0");
     expect(settingsSpan).toHaveAttribute("role", "button");

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -497,12 +497,18 @@ export function App() {
             </div>
 
             <div className="flex items-center justify-between text-slate-400">
-              <button type="button" aria-label="Settings coming soon" title="Settings coming soon" disabled className="cursor-not-allowed rounded-xl p-2 text-slate-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                <Settings className="size-5" aria-hidden="true" />
-              </button>
-              <button type="button" aria-label="Help coming soon" title="Help coming soon" disabled className="cursor-not-allowed rounded-xl p-2 text-slate-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                <CircleHelp className="size-5" aria-hidden="true" />
-              </button>
+              <span tabIndex={0} role="button" aria-disabled="true" title="Settings coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                <span className="sr-only">Settings coming soon</span>
+                <button type="button" disabled aria-hidden="true" className="pointer-events-none rounded-xl p-2 text-slate-600 transition">
+                  <Settings className="size-5" aria-hidden="true" />
+                </button>
+              </span>
+              <span tabIndex={0} role="button" aria-disabled="true" title="Help coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                <span className="sr-only">Help coming soon</span>
+                <button type="button" disabled aria-hidden="true" className="pointer-events-none rounded-xl p-2 text-slate-600 transition">
+                  <CircleHelp className="size-5" aria-hidden="true" />
+                </button>
+              </span>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
💡 **What:** 비활성화된 아이콘 버튼("Settings", "Help")을 포커스 가능한 `span`으로 감싸고 `sr-only` 텍스트를 추가했습니다.
🎯 **Why:** 네이티브 `<button disabled>`는 마우스 이벤트를 차단하고 탭 순서(tab order)에서 요소가 제외되므로, "출시 예정"이라는 시각적 툴팁(`title`)을 마우스 호버로 확인할 수 없고 스크린리더 또한 인식하지 못하는 접근성 문제가 있었습니다. 이를 개선하여 시각적 피드백과 키보드 접근성을 모두 살렸습니다.
📸 **Before/After:** 비활성화된 상태의 "Settings"나 "Help" 버튼에 마우스를 올렸을 때 이제 "Settings coming soon" 툴팁이 정상적으로 보입니다.
♿ **Accessibility:**
- 키보드 탭을 통해 비활성화된 버튼 영역에 접근할 수 있게 됨 (`tabIndex={0}`)
- `sr-only` 클래스를 통해 스크린 리더기가 버튼의 상태(aria-disabled)와 툴팁 내용을 정확하게 읽어주도록 개선됨

---
*PR created automatically by Jules for task [11089255984581716387](https://jules.google.com/task/11089255984581716387) started by @seonghobae*