### PR TITLE
중앙 스케줄러 credential 계약 문서화

### DIFF
--- a/docs/workflow/pr-review-merge-scheduler.md
+++ b/docs/workflow/pr-review-merge-scheduler.md
@@ -8,8 +8,10 @@ as central required workflows.
 
 The central scheduler keeps the open `develop` PR queue moving without bypassing repository rules.
 It runs in the target repository context through the organization required workflow, so mechanical
-update-branch, auto-merge, and merge actions are attributed to `github-actions[bot]`, not to the
-OpenCode review token. `OPENCODE_APPROVE_TOKEN` is not part of the scheduler contract.
+update-branch, auto-merge, and merge actions are performed by the selected workflow mutation
+credential, not by a maintainer's local `gh` session. The central scheduler may select
+`PR_REVIEW_MERGE_TOKEN`, `OPENCODE_APPROVE_TOKEN`, an exchanged OpenCode GitHub App token, or the
+workflow `GITHUB_TOKEN`, depending on which credential can perform the guarded repository mutation.
 
 The local repository may keep product CI, security, release, and build workflows. It must not restore
 repo-local copies of `opencode-review.yml`, `pr-review-merge-scheduler.yml`, or their `scripts/ci` helper implementations.
@@ -47,7 +49,7 @@ repo-local copies of `opencode-review.yml`, `pr-review-merge-scheduler.yml`, or 
 - Realistic threats: spammed review comments, merging a PR with unresolved conversations, merging without required checks, or hiding conflicts behind automation.
 - Mitigations: central required workflow source pinning, idempotent per-head review comment marker,
   explicit unresolved-thread check, retry-bounded GitHub API reads, required-check verification
-  through GitHub, conflict skip, normal merge only, and no admin bypass path.
+  through GitHub, conflict skip, guarded merge with `--match-head-commit`, and no admin bypass path.
 - Remaining risk: CodeRabbit and GitHub check state can be delayed or stale; the scheduler therefore only advances eligible PRs and leaves code-fix work to agents or maintainers.
 - Test points: organization ruleset inheritance, current-head OpenCode approval, unresolved review
   thread count, required-check rollup, approved behind PR, approved conflict-free PR, approved dirty PR,

--- a/services/analysis-engine/tests/test_supply_chain_policy.py
+++ b/services/analysis-engine/tests/test_supply_chain_policy.py
@@ -4958,8 +4958,8 @@ def test_opencode_approval_write_failure_updates_overview_only() -> None:
     assert "source-backed repository findings" in policy
 
 
-def test_pr_review_merge_scheduler_uses_github_actions_token() -> None:
-    """Ensure mechanical PR queue handling is attributed to GitHub Actions centrally."""
+def test_pr_review_merge_scheduler_uses_central_mutation_credential() -> None:
+    """Ensure mechanical PR queue handling uses the central mutation credential."""
     repo_root = Path(__file__).resolve().parents[3]
     policy = central_required_workflow_policy_text()
 
@@ -4967,8 +4967,12 @@ def test_pr_review_merge_scheduler_uses_github_actions_token() -> None:
     assert '"openai/o3"' in opencode_config
     assert '"openai/o4-mini"' in opencode_config
     assert_local_review_workflows_removed()
-    assert "github-actions[bot]" in policy
-    assert "`OPENCODE_APPROVE_TOKEN` is not part of the scheduler contract" in policy
+    assert "selected workflow mutation" in policy
+    assert "credential, not by a maintainer's local `gh` session" in policy
+    assert "PR_REVIEW_MERGE_TOKEN" in policy
+    assert "OPENCODE_APPROVE_TOKEN" in policy
+    assert "OpenCode GitHub App token" in policy
+    assert "workflow `GITHUB_TOKEN`" in policy
     assert "update-branch, auto-merge, and merge actions" in policy
 
 


### PR DESCRIPTION
## 요약
- 중앙 `ContextualWisdomLab/.github` 스케줄러가 `PR_REVIEW_MERGE_TOKEN`, `OPENCODE_APPROVE_TOKEN`, OpenCode GitHub App token, `GITHUB_TOKEN` 순으로 mutation credential을 선택할 수 있음을 BandScope 정책 문서에 반영합니다.
- repo-local `opencode-review.yml` / `pr-review-merge-scheduler.yml` 복제 금지 계약은 유지합니다.
- 공급망 정책 테스트가 중앙 scheduler credential 계약을 구버전 `github-actions[bot]` 단정으로 고정하지 않게 갱신합니다.

## 검증
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py::test_pr_review_merge_scheduler_uses_central_mutation_credential -q`
- `uv run --project services/analysis-engine pytest services/analysis-engine/tests/test_supply_chain_policy.py -q`
- `uv run --project services/analysis-engine ruff check services/analysis-engine/tests/test_supply_chain_policy.py`
- `git diff --check`

## 중앙화 근거
- 중앙 required workflow ruleset은 `ContextualWisdomLab/.github@main`의 OpenCode Review, Strix Security Scan, PR Review/Merge Scheduler를 사용합니다.
- 이 PR은 BandScope에 중앙 workflow 복제본을 추가하지 않습니다.