### PR TITLE
🎨 Palette: [UX improvement] 비활성화된 버튼의 툴팁 및 키보드 접근성 개선

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-06-29 - 비활성화된 네이티브 버튼의 툴팁 차단
 **Learning:** 네이티브 `<button>` 요소에 `disabled` 속성을 사용하면 마우스 호버 이벤트를 포함한 포인터 이벤트가 완전히 차단되어 표준 HTML `title` 속성이 툴팁으로 표시되지 않으며, 키보드 탭 순서(tab order)에서도 제외됩니다.
 **Action:** "출시 예정" 등 설명 툴팁이 필요한 비활성화된 액션 버튼의 경우, `title`을 버튼에 직접 붙이는 대신 포커스 가능한 `span` (`<span tabIndex={0} title={...} role="button" aria-disabled="true">`)으로 버튼을 감싸서 시각적 및 스크린 리더 접근성을 모두 보장해야 합니다.
+
+## 2024-07-01 - Testing components with focusable disabled button wrappers
+**Learning:** When native disabled buttons are wrapped in a focusable `span` to provide accessible tooltips, tests that previously found and clicked the `button` (by temporarily removing the `disabled` attribute) may fail or become overly complex. It is cleaner and more accurate to query the wrapper element (e.g. via its `title`) and fire events on it, reflecting the actual accessible DOM structure.
+**Action:** When testing UI components that wrap disabled buttons in a focusable span for accessibility (e.g., using a tooltip/title), use `screen.getByTitle(...)` to query the wrapper element for interactions like `fireEvent.click` rather than `screen.getByRole('button')`.

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1335,10 +1335,8 @@ describe("App", () => {
 
   it("does nothing when Save Project is clicked but there is no jobResult", () => {
     render(<App />);
-    const saveButton = screen.getByRole("button", { name: /save project/i });
-    // Remove disabled attribute to force the click for coverage
-    saveButton.removeAttribute("disabled");
-    fireEvent.click(saveButton);
+    const saveSpan = screen.getByTitle("Analyze a song to enable saving");
+    fireEvent.click(saveSpan);
     expect(mockSaveProject).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -603,16 +603,29 @@ export function App() {
                   <FolderOpen className="mr-2 size-4" aria-hidden="true" />
                   Open Project
                 </Button>
-                <Button
-                  onClick={jobResult ? handleSaveProject : undefined}
-                  disabled={!jobResult}
-                  variant="outline"
-                  className="min-h-11 border-white/10 bg-white/5 font-semibold text-slate-100 hover:bg-white/10 hover:text-white"
-                  aria-label="Save Project"
-                >
-                  <Save className="mr-2 size-4" aria-hidden="true" />
-                  Save Project
-                </Button>
+                {jobResult ? (
+                  <Button
+                    onClick={handleSaveProject}
+                    variant="outline"
+                    className="min-h-11 border-white/10 bg-white/5 font-semibold text-slate-100 hover:bg-white/10 hover:text-white"
+                    aria-label="Save Project"
+                  >
+                    <Save className="mr-2 size-4" aria-hidden="true" />
+                    Save Project
+                  </Button>
+                ) : (
+                  <span tabIndex={0} role="button" aria-disabled="true" title="Analyze a song to enable saving" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <Button
+                      disabled
+                      variant="outline"
+                      className="min-h-11 border-white/10 bg-white/5 font-semibold text-slate-100"
+                      aria-label="Save Project"
+                    >
+                      <Save className="mr-2 size-4" aria-hidden="true" />
+                      Save Project
+                    </Button>
+                  </span>
+                )}
                 <Button
                   onClick={handleStartAnalysis}
                   disabled={analysisInFlight || isStarting || !selectedBootstrap || isImporting}

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -311,18 +311,36 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
                 <p className="text-xs font-black uppercase tracking-[0.24em] text-emerald-200">Stem Player</p>
                 <p className="mt-1 text-sm font-semibold text-slate-100">{activeRoleDetails?.name ?? activeRole}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  <Button type="button" disabled title="Coming soon" variant="outline" className="min-h-11 cursor-not-allowed border-white/10 bg-white/5 text-slate-400">Play stem</Button>
-                  <Button type="button" disabled title="Coming soon" variant="outline" className="min-h-11 cursor-not-allowed border-white/10 bg-white/5 text-slate-400">Loop section</Button>
-                  <Button type="button" disabled title="Coming soon" variant="outline" className="min-h-11 cursor-not-allowed border-white/10 bg-white/5 text-slate-400">Solo / mute others</Button>
-                  <Button
-                    type="button"
-                    disabled={!canTranscribeBass}
-                    title={canTranscribeBass ? "Transcribe part" : `${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`}
-                    variant="outline"
-                    className="min-h-11 border-emerald-300/20 bg-emerald-300/10 font-semibold text-emerald-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-500"
-                  >
-                    Transcribe Bass
-                  </Button>
+                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Play stem</Button>
+                  </span>
+                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Loop section</Button>
+                  </span>
+                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Solo / mute others</Button>
+                  </span>
+                  {canTranscribeBass ? (
+                    <Button
+                      type="button"
+                      title="Transcribe part"
+                      variant="outline"
+                      className="min-h-11 border-emerald-300/20 bg-emerald-300/10 font-semibold text-emerald-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-500"
+                    >
+                      Transcribe Bass
+                    </Button>
+                  ) : (
+                    <span tabIndex={0} role="button" aria-disabled="true" title={`${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`} className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                      <Button
+                        type="button"
+                        disabled
+                        variant="outline"
+                        className="min-h-11 border-emerald-300/20 bg-emerald-300/10 font-semibold text-emerald-100 disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-500"
+                      >
+                        Transcribe Bass
+                      </Button>
+                    </span>
+                  )}
                 </div>
                 <div className="mt-4 grid gap-3 lg:grid-cols-2">
                   <div className="rounded-xl border border-cyan-300/20 bg-cyan-300/[0.06] p-3">


### PR DESCRIPTION
💡 **What:** App.tsx 와 Workspace.tsx 내의 비활성화된 버튼들을 포커스 가능한 `span` (`tabIndex={0}`, `role="button"`, `aria-disabled="true"`) 으로 감쌌습니다.
🎯 **Why:** 네이티브 `disabled` 버튼은 마우스 호버 등 포인터 이벤트를 차단하고 키보드 탭 순서(tab order)에서 제외되기 때문에, 사용자(시각 사용자 및 스크린 리더 사용자 모두)에게 버튼이 비활성화된 이유(예: "Coming soon")를 설명하는 툴팁을 제공할 수 없습니다. 이를 `span` 래퍼로 우회하여 접근성을 높였습니다.
📸 **Before/After:** 시각적으로는 동일하지만, 이제 비활성화된 버튼 위에 마우스를 올리거나 키보드로 탭 이동 시 설명 툴팁이 나타납니다.
♿ **Accessibility:** 마우스 호버 툴팁 지원 및 스크린 리더의 비활성화 사유 읽기(title 속성) 지원, 키보드 탐색(tab order) 지원이 추가되었습니다.

---
*PR created automatically by Jules for task [4811607835738980542](https://jules.google.com/task/4811607835738980542) started by @seonghobae*