### PR TITLE
Add Figma-only design system handoff

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -212,6 +212,17 @@ describe("App", () => {
     expect(screen.getByText(/YouTube only leaves the app when you choose import/i)).toBeTruthy();
   });
 
+  it("keeps source controls before the analysis summary", () => {
+    render(<App />);
+
+    const sourceControls = screen.getByLabelText("Source controls");
+    const analysisSummary = screen.getByLabelText("Analysis summary");
+
+    expect(sourceControls.compareDocumentPosition(analysisSummary) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(sourceControls).toHaveTextContent(/Choose local audio/i);
+    expect(sourceControls).toHaveTextContent(/Import YouTube/i);
+  });
+
   it("renders the loaded song as a dark rehearsal command board", async () => {
     mockLoadProject.mockResolvedValueOnce(succeededResult().result);
     render(<App />);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -534,14 +534,6 @@ export function App() {
             ))}
           </nav>
 
-          <header className="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-            <MetricCard icon={<Clock3 className="size-5" aria-hidden="true" />} label="Tempo" value="Pending" detail="Awaiting reliable detection" accent="text-sky-300" />
-            <MetricCard icon={<KeyRound className="size-5" aria-hidden="true" />} label="Key" value="Pending" detail="No trusted key yet" accent="text-cyan-300" />
-            <MetricCard icon={<Wand2 className="size-5" aria-hidden="true" />} label="Transpose" value="Pending" detail="Review after key detection" accent="text-blue-300" />
-            <ConfidenceMetric song={jobResult} />
-            <MetricCard icon={<Star className="size-5 fill-amber-300 text-amber-300" aria-hidden="true" />} label="Priority" value={priorityLabel(jobResult)} detail={jobResult?.exportSummary?.headline ?? "Choose or open audio"} accent="text-amber-300" />
-          </header>
-
           <section aria-label="Source controls" className="mb-4 rounded-3xl border border-white/10 bg-slate-950/72 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.25)] backdrop-blur-xl">
             <div className="grid gap-4 2xl:grid-cols-[1.4fr_minmax(0,1fr)_auto] 2xl:items-center">
               <div>
@@ -556,34 +548,36 @@ export function App() {
                 </p>
               </div>
 
-              <div className="grid min-w-0 gap-3 sm:grid-cols-[auto_1fr_auto] sm:items-center 2xl:grid-cols-[auto_1fr]">
+              <div className="grid min-w-0 gap-3 xl:grid-cols-[auto_minmax(0,1fr)] xl:items-center">
                 <Button
                   onClick={handleChooseLocalAudio}
                   disabled={analysisInFlight || isStarting || isImporting}
                   variant="secondary"
-                  className="min-h-11 border border-cyan-300/20 bg-cyan-300/10 font-semibold text-cyan-50 hover:bg-cyan-300/20"
+                  className="min-h-11 w-full border border-cyan-300/20 bg-cyan-300/10 font-semibold text-cyan-50 hover:bg-cyan-300/20 xl:w-auto"
                   aria-label="Choose local audio"
                 >
                   <Upload className="mr-2 size-4" aria-hidden="true" />
                   {t("chooseLocalAudio")}
                 </Button>
 
-                <div className="flex min-w-0 items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-1.5">
-                  <Music2 className="ml-2 size-4 shrink-0 text-rose-300" aria-hidden="true" />
-                  <Input
-                    type="text"
-                    placeholder={t("youtubePlaceholder")}
-                    value={youtubeUrl}
-                    onChange={(e) => setYoutubeUrl(e.target.value)}
-                    disabled={analysisInFlight || isStarting || isImporting}
-                    className="h-10 flex-1 border-0 bg-transparent text-slate-100 placeholder:text-slate-500 focus-visible:ring-cyan-300"
-                    aria-label="YouTube URL"
-                  />
+                <div className="grid min-w-0 gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-1.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Music2 className="ml-2 size-4 shrink-0 text-rose-300" aria-hidden="true" />
+                    <Input
+                      type="text"
+                      placeholder={t("youtubePlaceholder")}
+                      value={youtubeUrl}
+                      onChange={(e) => setYoutubeUrl(e.target.value)}
+                      disabled={analysisInFlight || isStarting || isImporting}
+                      className="h-10 flex-1 border-0 bg-transparent text-slate-100 placeholder:text-slate-500 focus-visible:ring-cyan-300"
+                      aria-label="YouTube URL"
+                    />
+                  </div>
                   <Button
                     onClick={handleImportYoutube}
                     disabled={!youtubeUrl || analysisInFlight || isStarting || isImporting}
                     variant="outline"
-                    className="min-h-10 border-white/10 bg-white/5 font-semibold text-slate-100 hover:bg-white/10 hover:text-white"
+                    className="min-h-10 w-full border-white/10 bg-white/5 font-semibold text-slate-100 hover:bg-white/10 hover:text-white sm:w-auto"
                     aria-label="Import YouTube"
                   >
                     {isImporting && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
@@ -592,7 +586,7 @@ export function App() {
                 </div>
               </div>
 
-              <div className="flex flex-wrap justify-start gap-2 2xl:justify-end">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 2xl:flex 2xl:flex-wrap 2xl:justify-end">
                 <Button
                   onClick={handleLoadProject}
                   disabled={analysisInFlight || isStarting}
@@ -690,6 +684,14 @@ export function App() {
               </div>
             </div>
           </section>
+
+          <header aria-label="Analysis summary" className="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <MetricCard icon={<Clock3 className="size-5" aria-hidden="true" />} label="Tempo" value="Pending" detail="Awaiting reliable detection" accent="text-sky-300" />
+            <MetricCard icon={<KeyRound className="size-5" aria-hidden="true" />} label="Key" value="Pending" detail="No trusted key yet" accent="text-cyan-300" />
+            <MetricCard icon={<Wand2 className="size-5" aria-hidden="true" />} label="Transpose" value="Pending" detail="Review after key detection" accent="text-blue-300" />
+            <ConfidenceMetric song={jobResult} />
+            <MetricCard icon={<Star className="size-5 fill-amber-300 text-amber-300" aria-hidden="true" />} label="Priority" value={priorityLabel(jobResult)} detail={jobResult?.exportSummary?.headline ?? "Choose or open audio"} accent="text-amber-300" />
+          </header>
 
           <section className="animate-in fade-in duration-500 ease-out fill-mode-both">
             {renderWorkspaceState()}

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,64 @@
+# BandScope Design System
+
+BandScope uses the Figma file as the self-contained design and implementation handoff. This repository mirrors the contract for review and maintenance, but the Figma file must remain usable without Code Connect, Figma access tokens, organization-tier platform features, or external repo docs.
+
+Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
+
+## Source Of Truth
+
+- Visual structure, component anatomy, states, layout examples, implementation paths, prop/state translation, UI repair guidance, screen blueprints, and QA rules live in Figma.
+- Production component APIs, tokens, accessibility behavior, and implementation examples are mirrored in this directory for code review.
+- Frontend work must resolve conflicts by checking both Figma-local contract pages and production code.
+- Figma component names and variant names should mirror the repo contract so visual review remains straightforward.
+- Do not introduce required Figma platform features into build, test, release, or CI flows.
+
+## Working Model
+
+1. Start from the Figma component or screen to understand visual intent.
+2. Read `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit` in the Figma file.
+3. Use [component-contract.md](component-contract.md) as a repo mirror of the Figma-only contract.
+4. Implement with the listed code component and allowed props before adding local markup.
+5. Use documented token classes and component variants first; add one-off classes only for domain-specific visual emphasis.
+6. Review the PR against the publisher and frontend checklists below.
+
+Codex and other implementation agents must follow [figma-to-code-workflow.md](figma-to-code-workflow.md) when using the Figma file as development input.
+
+## Frontend Engineer Checklist
+
+- Use the canonical component path and current runtime API listed on Figma page `31 Component Contract Catalog`.
+- Treat [component-contract.md](component-contract.md) as a review mirror, not a replacement for the Figma page.
+- Keep `Button`, `Badge`, `Input`, `Tabs`, `Progress`, and `Card` semantics intact instead of recreating them with raw elements.
+- Preserve focus states, disabled states, `aria-invalid`, labels, and keyboard-accessible regions.
+- Keep mobile touch actions at 40px or larger when the design uses the Touch state.
+- Keep source controls above the fold on narrow screens and allow wrapping before clipping.
+- Preserve the contract test in `apps/desktop/src/App.test.tsx` that keeps `Source controls` before `Analysis summary`.
+- Avoid nested card surfaces unless the inner surface is an actual repeated item or interactive module.
+- Keep label letter spacing at `0` unless the current code already uses uppercase status metadata.
+
+## Publisher Checklist
+
+- Build pages from existing components and patterns before adding new UI.
+- Treat Figma spacing, grouping, and hierarchy as the visual target, but use repo component APIs as the implementation target.
+- Use concise headings inside panels; reserve display-scale type for page-level moments.
+- Use icon buttons for recognizable actions and visible text buttons for commands that need wording.
+- Check desktop and mobile screenshots for clipped text, cramped controls, hidden primary actions, and overlapping status content.
+- When a Figma pattern has no extracted code component yet, keep it local to the feature and mark it for extraction in the backlog section of [component-contract.md](component-contract.md). Page 31 explicitly names these feature-local patterns.
+
+## Figma Maintenance
+
+- Keep the Figma Handoff Notes page linked to Figma-only pages first: `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit`.
+- Keep component descriptions focused on code path, usage, state mapping, and known UI defects.
+- Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
+- If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
+- If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
+
+## Current UI Defects Covered
+
+- Mobile source controls clipping: use wrapping source-control layout and Touch button sizing.
+- First analysis path buried below metrics: keep source controls ahead of secondary metrics on narrow screens.
+- Source-first reading order regression: covered by the `keeps source controls before the analysis summary` App test.
+- Inconsistent action styling: route actions through `Button` and icon-button sizing.
+- Small touch targets: use `size="lg"` or `size="icon-lg"` when the control is mobile-primary.
+- Compact navigation clipping: allow trigger wrapping and avoid fixed-width labels.
+- Heavy nested cards: prefer `Card` once per logical panel, with repeated rows inside.
+- Dense uppercase labels: keep metadata short and use normal body text for explanations.

--- a/docs/design-system/component-contract.md
+++ b/docs/design-system/component-contract.md
@@ -1,0 +1,94 @@
+# Component Contract
+
+This contract connects the BandScope Figma design system to production React components without requiring Figma Code Connect or Figma platform publishing.
+
+Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
+
+The authoritative Figma view is `31 Component Contract Catalog`. This file mirrors that page for review only.
+
+## Canonical Components
+
+| Figma component | Figma node | Code path | Use |
+| --- | --- | --- | --- |
+| Button / Default | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-84 | `apps/desktop/src/components/ui/button.tsx` | Primary actions with `variant="default"` and `size="default"`, `sm`, or `lg`. |
+| Button / Outline | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-121 | `apps/desktop/src/components/ui/button.tsx` | Secondary or framed actions with `variant="outline"`. |
+| Button / Secondary | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-167 | `apps/desktop/src/components/ui/button.tsx` | Low-emphasis filled actions with `variant="secondary"`. |
+| Button / Ghost | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-213 | `apps/desktop/src/components/ui/button.tsx` | Toolbar actions with `variant="ghost"`. |
+| Button / Destructive | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-250 | `apps/desktop/src/components/ui/button.tsx` | Destructive or high-risk actions with `variant="destructive"`. |
+| Button / Link | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-287 | `apps/desktop/src/components/ui/button.tsx` | Inline actions with `variant="link"` and usually `size="sm"`. |
+| Button / Source | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-324 | `apps/desktop/src/components/ui/button.tsx` | Design pattern only. Runtime uses `variant="secondary"` or `variant="outline"` plus source-control `className`; no dedicated source Button variant exists yet. |
+| Icon Button | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-407 | `apps/desktop/src/components/ui/button.tsx` | Icon-only actions require `aria-label`; use `size="icon-sm"`, `icon`, or `icon-lg`. |
+| Input | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-471 | `apps/desktop/src/components/ui/input.tsx` | Text, URL, and file inputs; use native `type`, `placeholder`, `disabled`, and `aria-invalid`. |
+| Badge | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-494 | `apps/desktop/src/components/ui/badge.tsx` | Compact metadata with `variant="default"`, `secondary`, `destructive`, `outline`, `ghost`, or `link`. |
+| Tabs Trigger | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-517 | `apps/desktop/src/components/ui/tabs.tsx` | Pair `TabsList variant="default" | "line"` with `TabsTrigger`; do not render triggers outside a `Tabs` root. |
+| Navigation Item | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-559 | `apps/desktop/src/App.tsx` | Feature-local `NAV_ITEMS` button pattern; active maps to `aria-current="page"` and inactive maps to `disabled`. |
+| Progress | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-602 | `apps/desktop/src/components/ui/progress.tsx` | Use `value` for progress; add indicator color classes only for semantic tone. |
+| Console Panel | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=18-632 | `apps/desktop/src/components/ui/card.tsx` | Use `Card`, `CardHeader`, `CardTitle`, and `CardContent`; `size="sm"` is the compact state. |
+| BandScope Mark | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-163 | `apps/desktop/src/App.tsx` | Feature-local `BandScopeMark()` currently has no props; Figma size variants are visual guidance only. |
+| Metric Card | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-216 | `apps/desktop/src/App.tsx` | Feature-local `MetricCard({ icon, label, value, detail, accent? })`. Metrics follow source controls on mobile. |
+| Confidence Badge | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-239 | `apps/desktop/src/features/workspace/ConfidenceBadge.tsx` | Use `level: ConfidenceLevel`; no `score` or `label` prop exists in current code. |
+| Status Pill | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-283 | `apps/desktop/src/features/workspace/Workspace.tsx` | Design pattern only. Current code uses `formatStatusLabel(status)` inside local badge-like markup. |
+| Role Switcher | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-337 | `apps/desktop/src/features/workspace/RoleSwitcher.tsx` | Use `roles`, `activeRole`, and `onRoleChange`; `null` means all roles. |
+| Section Roadmap Card | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-402 | `apps/desktop/src/features/workspace/SectionRoadmap.tsx` | Use `song`, `activeRole`, and optional `onSongUpdate`; avoid rebuilding its internal card layout. |
+| Song Structure Timeline | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-457 | `apps/desktop/src/features/workspace/Workspace.tsx` | Feature-local `SongStructure({ sections, t })` memo component; not exported. |
+| Groove Map | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-526 | `apps/desktop/src/features/workspace/GrooveMap.tsx` | Use `notes?: TranscriptionNote[]` and `isLoading?: boolean`; preserve scrollable region semantics and note labels. |
+| Source Control Stack | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-655 | `apps/desktop/src/App.tsx` | Feature-local source controls for local audio, YouTube URL import, project actions, and Start Analysis; keep before metrics at 375px. |
+| Export Action Group | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-731 | `apps/desktop/src/features/workspace/Workspace.tsx` | Feature-local export buttons call `handleExportCueSheet`, `handleExportChart`, and `handleExportHandoff`. |
+
+## Prop And State Mapping
+
+### Button
+
+- Figma `Size=Compact` maps to `size="sm"` for text buttons and `size="icon-sm"` for icon buttons.
+- Figma `Size=Default` maps to `size="default"` for text buttons and `size="icon"` for icon buttons.
+- Figma `Size=Touch` maps to `size="lg"` or `size="icon-lg"`; add `min-h-11` only when the surrounding layout needs a larger hit target.
+- Figma `State=Disabled` maps to the native `disabled` prop.
+- Figma focused states must be implemented through existing `focus-visible` classes, not custom hover-only styling.
+- Figma `Button / Source` is a source-control pattern, not a runtime variant. Use `variant="secondary"` or `variant="outline"` with the documented source-control `className` until a dedicated variant is added to `button.tsx`.
+
+### Input
+
+- Figma `Type=Text`, `URL`, and `File` map to native `type="text"`, `url`, and `file`.
+- Figma `State=Error` maps to `aria-invalid`.
+- Figma `State=Disabled` maps to `disabled`.
+- Keep placeholder text useful; do not use placeholder text as the only label for important workflows.
+
+### Badge And Confidence
+
+- Use `Badge` for general metadata and `ConfidenceBadge` for confidence status.
+- Use `ConfidenceBadge` with `level` from shared types only: `low`, `medium`, `high`.
+- Do not pass `score` or `label` to `ConfidenceBadge`; those props do not exist in the current runtime component.
+- Keep badges short enough to avoid wrapping inside dense cards.
+
+### Tabs
+
+- Use `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` together.
+- Use `TabsList variant="line"` for compact timeline/navigation surfaces.
+- Disabled triggers use the primitive `disabled` prop.
+
+### Progress
+
+- Use `Progress value={number}` for status progress.
+- Tone-specific colors belong on `ProgressIndicator` or scoped child selectors.
+- Provide adjacent live text when progress reflects an active asynchronous job.
+
+## Pattern Backlog
+
+These Figma patterns are valid visual guidance but are not yet extracted as standalone code components. Use the existing feature markup and open a follow-up extraction task when reuse appears twice.
+
+| Figma pattern | Current implementation home | Extraction trigger |
+| --- | --- | --- |
+| Source Control Stack | `apps/desktop/src/App.tsx` source controls section | Extract when another intake surface needs the same local audio, YouTube URL import, project, and analysis actions. |
+| Navigation Item | `apps/desktop/src/App.tsx` shell navigation | Extract when navigation appears outside the app shell. |
+| Metric Card | `apps/desktop/src/App.tsx` `MetricCard` | Extract when metrics move into feature pages or dashboards. |
+| Status Pill | `apps/desktop/src/features/workspace/Workspace.tsx` | Extract when assignment/comment/approval status UI is reused. |
+| Song Structure Timeline | `apps/desktop/src/features/workspace/Workspace.tsx` | Extract when timeline editing or playback controls are added. |
+| Export Action Group | `apps/desktop/src/features/workspace/Workspace.tsx` | Extract when export controls are reused outside the workspace header. |
+
+## PR Review Rules
+
+- New UI should cite the matching Figma node and code path in the PR description when it implements a design-system component.
+- A new component variant must update this file, the relevant component tests, and the Figma component notes.
+- A new Figma-only pattern must enter the Pattern Backlog before being reused.
+- Any deliberate visual divergence from Figma should state whether the repo contract or accessibility requirement caused it.
+- Do not add Code Connect, Figma token, or Figma publish requirements to CI.

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -1,0 +1,71 @@
+# Figma To Code Workflow
+
+This workflow is for Codex, Frontend Engineers, and Publishers using the BandScope Figma file without Code Connect.
+
+Figma is the visual, structural, and handoff input. The repository remains the runtime source of truth for tests and release behavior, but the Figma file must carry enough implementation guidance to start work without opening these docs. Missing implementation detail inside Figma is a design-system defect.
+
+## Can Codex Develop From This Figma?
+
+Yes, with translation. Codex can read the Figma file for component anatomy, variants, layout, text hierarchy, visual states, implementation paths, current runtime prop mappings, TSX examples, screen blueprints, and design-defect guidance. Codex must then translate that intent into the existing React components and Tailwind classes in production code.
+
+Codex must not paste generated Figma code directly into the app. Generated Figma code is reference material only.
+
+## Required Loop
+
+1. Identify the target Figma node, screen, or component set.
+2. Read Figma structure and variants through Figma MCP or the node URL.
+3. Read `31 Component Contract Catalog` for the matching source path, current runtime API, TSX example, and QA note.
+4. Read `32 Screen Blueprints` for mobile and desktop placement before changing layout.
+5. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
+6. Inspect the actual code component before editing.
+7. Implement with existing components first.
+8. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
+9. Verify with typecheck and the narrowest useful test command.
+10. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
+11. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
+
+## What Figma Can Provide
+
+- Component names, node IDs, descriptions, variants, and component property definitions.
+- Source paths, current runtime API notes, TSX examples, and QA notes visibly stored on `31 Component Contract Catalog` and mirrored in component descriptions plus `bandscope` shared metadata.
+- Visual measurements, spacing, hierarchy, state examples, and screenshots.
+- Mobile 375x812 and desktop 1440x900 repair targets on `32 Screen Blueprints`.
+- Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
+- Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
+- UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
+
+## What The Repo Must Provide
+
+- Canonical React component paths and prop names.
+- Allowed variants, sizes, accessibility semantics, and composition rules.
+- Tests, build behavior, and CI requirements.
+- Decisions about whether a Figma pattern should become a reusable code component.
+
+## Translation Rules
+
+- Translate Figma `Button / Default` through `Button`, not raw `button` markup.
+- Translate Figma `Input` states through native `type`, `disabled`, and `aria-invalid`.
+- Translate Figma `Tabs Trigger` through `Tabs`, `TabsList`, and `TabsTrigger`.
+- Translate confidence UI through `ConfidenceBadge`, not local color classes.
+- Translate Figma pattern components in the backlog as feature-local markup until reuse justifies extraction.
+- Keep generated Figma asset URLs out of production code unless the asset has been intentionally added to the repo.
+
+## When To Stop And Reassess
+
+- The Figma component has no matching contract entry.
+- A Figma variant has no supported code prop or class strategy.
+- A Figma contract names a prop that does not exist in the current runtime component.
+- A required implementation detail exists only in repo docs and not in Figma.
+- A generated Figma layout would require duplicating an existing component.
+- The implementation would add a Figma token, access token, publish step, or platform-plan requirement.
+- Visual parity conflicts with accessibility, keyboard behavior, localization, or responsive constraints.
+
+## PR Notes
+
+PRs that implement Figma-driven UI should include:
+
+- Figma node URL or page name.
+- Contract entry used.
+- Code component paths touched.
+- Verification commands, contract tests, and screenshot viewports, when applicable.
+- Any divergence from Figma and the reason.


### PR DESCRIPTION
## Summary
- Add the Figma-only design-system mirror docs for frontend engineering and publisher handoff.
- Update the app shell so Source controls render before Analysis summary metrics and wrap safely on narrow screens.
- Add a regression test that locks the Figma page 32 source-first reading order.

## Figma
- File: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
- Contract pages: 28 Implementation Contract, 29 UI Repair Playbook, 30 Publisher + QA Matrix, 31 Component Contract Catalog, 32 Screen Blueprints, 33 Figma-Only Readiness Audit.
- Added page 33 audit row `57:2` for Product Design regression proof.

## Verification
- `py -3 scripts/checks/verify_docs.py`
- `npm run typecheck --workspace @bandscope/desktop`
- `npm run lint --workspace @bandscope/desktop`
- `npm run build --workspace @bandscope/desktop`
- `npm run test --workspace @bandscope/desktop` (8 files, 118 tests)

## Notes
- Code Connect remains intentionally optional; no Figma platform, access-token, publish, or CI dependency was added.
- Browser screenshot capture was attempted locally but blocked by missing Chrome/Edge executable and Playwright Chromium download failure due `SELF_SIGNED_CERT_IN_CHAIN`.