### PR TITLE
Record design-system tool access limits

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -11,6 +11,7 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 - Frontend work must resolve conflicts by checking both Figma-local contract pages and production code.
 - Figma component names and variant names should mirror the repo contract so visual review remains straightforward.
 - Do not introduce required Figma platform features into build, test, release, or CI flows.
+- `Ponytail` and `Superpowers` are recorded on Figma page `33 Figma-Only Readiness Audit` as unavailable callable tools for this handoff. Treat them as named review perspectives only unless a future session exposes actual tools or project standards for them.
 
 ## Working Model
 
@@ -51,6 +52,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
 - If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
+- Keep the `Ponytail and Superpowers access note` on page 33 current whenever those tools or standards become available.
 
 ## Current UI Defects Covered
 

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -31,6 +31,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Visual measurements, spacing, hierarchy, state examples, and screenshots.
 - Mobile 375x812 and desktop 1440x900 repair targets on `32 Screen Blueprints`.
 - Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
+- Tool access limits on `33 Figma-Only Readiness Audit`, including the current `Ponytail` and `Superpowers` note.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -56,6 +57,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A Figma variant has no supported code prop or class strategy.
 - A Figma contract names a prop that does not exist in the current runtime component.
 - A required implementation detail exists only in repo docs and not in Figma.
+- A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
 - A generated Figma layout would require duplicating an existing component.
 - The implementation would add a Figma token, access token, publish step, or platform-plan requirement.
 - Visual parity conflicts with accessibility, keyboard behavior, localization, or responsive constraints.


### PR DESCRIPTION
## Summary
- Record the `Ponytail` and `Superpowers` access limitation in the repo mirror.
- Match Figma page 33, which now contains `Audit row / Ponytail and Superpowers access note` (`58:2`).

## Verification
- `py -3 scripts/checks/verify_docs.py`
- Code Connect artifact search: no package/config/template/token requirement found.

## Notes
- This is a documentation-only follow-up to PR #512.