### PR TITLE
Document Figma visual audit hardening

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -11,7 +11,7 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 - Frontend work must resolve conflicts by checking both Figma-local contract pages and production code.
 - Figma component names and variant names should mirror the repo contract so visual review remains straightforward.
 - Do not introduce required Figma platform features into build, test, release, or CI flows.
-- `Ponytail` and `Superpowers` are recorded on Figma page `33 Figma-Only Readiness Audit` as unavailable callable tools for this handoff. Treat them as named review perspectives only unless a future session exposes actual tools or project standards for them.
+- `Ponytail` and `Superpowers` are recorded on Figma page `33 Figma-Only Readiness Audit` as unavailable callable tools for this handoff. The explicit plugin links were rechecked on 2026-07-01 and still exposed no callable tools or install candidates, so treat them as named review perspectives only unless a future session exposes actual tools or project standards for them.
 
 ## Working Model
 
@@ -23,6 +23,14 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 6. Review the PR against the publisher and frontend checklists below.
 
 Codex and other implementation agents must follow [figma-to-code-workflow.md](figma-to-code-workflow.md) when using the Figma file as development input.
+
+## Visual Audit Snapshot
+
+- Figma page `33 Figma-Only Readiness Audit` contains the `2026-07-01 visual pass - PASS` evidence row.
+- Pages `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit` each contain one visible root frame.
+- The 2026-07-01 Figma audit found no empty root, hidden root, top-level overlap candidate, or remaining manual-height text clipping candidate on pages 28-33 after the intro and gap text was changed to auto-height.
+- `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
+- If a Figma metadata overview appears to show pages 28-33 as empty, inspect the page root node directly before treating it as a defect. The verified root IDs are `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, and `50:133`.
 
 ## Frontend Engineer Checklist
 
@@ -52,7 +60,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
 - If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
-- Keep the `Ponytail and Superpowers access note` on page 33 current whenever those tools or standards become available.
+- Keep the `Ponytail and Superpowers access note` and `2026-07-01 visual pass` row on page 33 current whenever those tools, standards, or visual audit results change.
 
 ## Current UI Defects Covered
 

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -16,13 +16,14 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 2. Read Figma structure and variants through Figma MCP or the node URL.
 3. Read `31 Component Contract Catalog` for the matching source path, current runtime API, TSX example, and QA note.
 4. Read `32 Screen Blueprints` for mobile and desktop placement before changing layout.
-5. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
-6. Inspect the actual code component before editing.
-7. Implement with existing components first.
-8. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
-9. Verify with typecheck and the narrowest useful test command.
-10. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
-11. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
+5. Check `33 Figma-Only Readiness Audit` for current visual audit evidence and tool access limits before deciding a Figma page is empty or a plugin-backed review is required.
+6. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
+7. Inspect the actual code component before editing.
+8. Implement with existing components first.
+9. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
+10. Verify with typecheck and the narrowest useful test command.
+11. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
+12. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
 
 ## What Figma Can Provide
 
@@ -31,7 +32,8 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Visual measurements, spacing, hierarchy, state examples, and screenshots.
 - Mobile 375x812 and desktop 1440x900 repair targets on `32 Screen Blueprints`.
 - Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
-- Tool access limits on `33 Figma-Only Readiness Audit`, including the current `Ponytail` and `Superpowers` note.
+- Tool access limits on `33 Figma-Only Readiness Audit`, including the 2026-07-01 `Ponytail` and `Superpowers` recheck note.
+- Visual audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have visible root frames and no remaining manual-height text clipping candidates.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -58,6 +60,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A Figma contract names a prop that does not exist in the current runtime component.
 - A required implementation detail exists only in repo docs and not in Figma.
 - A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
+- A page-level Figma metadata overview appears empty but the page root node has not been inspected directly.
 - A generated Figma layout would require duplicating an existing component.
 - The implementation would add a Figma token, access token, publish step, or platform-plan requirement.
 - Visual parity conflicts with accessibility, keyboard behavior, localization, or responsive constraints.


### PR DESCRIPTION
## Summary
- Record the 2026-07-01 Figma visual pass for pages 28-33 in the design-system repo mirror
- Document the explicit Ponytail/Superpowers plugin recheck result and page-root fallback when metadata appears empty
- Keep the Figma-only handoff free of Code Connect or Figma token/platform dependencies

## Figma Evidence
- File: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
- Page 33: `Figma-Only Readiness Audit / Evidence` now includes `2026-07-01 visual pass - PASS`
- Verified root IDs: `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, `50:133`

## Verification
- `py -3 scripts/checks/verify_docs.py`
- `npm run typecheck --workspace @bandscope/desktop`
- `npm run lint --workspace @bandscope/desktop`
- `npm run build --workspace @bandscope/desktop`
- `npm run test --workspace @bandscope/desktop`
- Code Connect/Figma token dependency search returned no package/config/token matches

## Implementation Note
No app code changed: the Figma audit confirmed the empty-page concern was a Figma handoff/documentation issue, while the source-first UI target on page 32 is already implemented in `apps/desktop/src/App.tsx` and covered by `apps/desktop/src/App.test.tsx`.