### PR TITLE
Document Figma placeholder section hardening

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -29,8 +29,12 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Figma page `33 Figma-Only Readiness Audit` contains the `2026-07-01 visual pass - PASS` evidence row.
 - Pages `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit` each contain one visible root frame.
 - The 2026-07-01 Figma audit found no empty root, hidden root, top-level overlap candidate, or remaining manual-height text clipping candidate on pages 28-33 after the intro and gap text was changed to auto-height.
+- Figma page `33 Figma-Only Readiness Audit` also contains the `2026-07-01 placeholder section pass - PASS` evidence row.
+- Page `32 Screen Blueprints` was hardened after the first visual pass: its mobile and desktop blocks now show concrete UI anatomy for header/role controls, source controls, status/progress, metric cards, navigation, console details, section roadmap, groove map, and export actions.
+- The stricter page 32 audit found `0` label-only/empty blueprint sections and `0` text clipping candidates after those additions.
 - `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
 - If a Figma metadata overview appears to show pages 28-33 as empty, inspect the page root node directly before treating it as a defect. The verified root IDs are `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, and `50:133`.
+- If a blueprint block is only a large labeled box, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The 2026-07-01 audit found the code was implemented, so Figma page 32 was corrected instead of changing app code.
 
 ## Frontend Engineer Checklist
 
@@ -59,8 +63,9 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Keep component descriptions focused on code path, usage, state mapping, and known UI defects.
 - Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
 - If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
+- If a Figma screen blueprint contains placeholder-only or label-only sections, compare against the runtime code first. Implement code only when the surface is missing; otherwise fill the Figma blueprint with concrete UI anatomy.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
-- Keep the `Ponytail and Superpowers access note` and `2026-07-01 visual pass` row on page 33 current whenever those tools, standards, or visual audit results change.
+- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, and `2026-07-01 placeholder section pass` rows on page 33 current whenever those tools, standards, or visual audit results change.
 
 ## Current UI Defects Covered
 

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -19,11 +19,12 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 5. Check `33 Figma-Only Readiness Audit` for current visual audit evidence and tool access limits before deciding a Figma page is empty or a plugin-backed review is required.
 6. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
 7. Inspect the actual code component before editing.
-8. Implement with existing components first.
-9. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
-10. Verify with typecheck and the narrowest useful test command.
-11. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
-12. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
+8. If a Figma blueprint block is placeholder-only, verify whether the matching runtime surface exists before coding. Fill Figma when the code already exists; implement code only when the surface is genuinely missing.
+9. Implement with existing components first.
+10. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
+11. Verify with typecheck and the narrowest useful test command.
+12. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
+13. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
 
 ## What Figma Can Provide
 
@@ -34,6 +35,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
 - Tool access limits on `33 Figma-Only Readiness Audit`, including the 2026-07-01 `Ponytail` and `Superpowers` recheck note.
 - Visual audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have visible root frames and no remaining manual-height text clipping candidates.
+- Placeholder-section audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 32 has no remaining label-only blueprint sections.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -61,6 +63,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A required implementation detail exists only in repo docs and not in Figma.
 - A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
 - A page-level Figma metadata overview appears empty but the page root node has not been inspected directly.
+- A Figma screen blueprint has a large placeholder-only or label-only section and the matching runtime surface has not been checked.
 - A generated Figma layout would require duplicating an existing component.
 - The implementation would add a Figma token, access token, publish step, or platform-plan requirement.
 - Visual parity conflicts with accessibility, keyboard behavior, localization, or responsive constraints.


### PR DESCRIPTION
## Summary
- Record the 2026-07-01 Figma placeholder-section pass for page 32 in the design-system repo mirror
- Clarify that placeholder-only blueprint blocks must be checked against runtime code before coding
- Keep the handoff Code Connect-free and platform-token-free

## Figma Evidence
- File: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
- Page 32: `Screen Blueprints / Mobile and desktop repair targets` now fills previously label-only mobile and desktop blueprint sections with concrete UI anatomy
- Page 33: `Figma-Only Readiness Audit / Evidence` now includes `2026-07-01 placeholder section pass - PASS`
- Strict page 32 audit result: low-detail candidates `0`; text clipping candidates `0`

## Implementation Decision
No app code changed. The empty/label-only sections were Figma handoff defects, not missing app implementation. The matching runtime surfaces already exist in `apps/desktop/src/App.tsx` and `apps/desktop/src/features/workspace/Workspace.tsx`.

## Verification
- `py -3 scripts/checks/verify_docs.py`
- `npm run typecheck --workspace @bandscope/desktop`
- `npm run lint --workspace @bandscope/desktop`
- `npm run build --workspace @bandscope/desktop`
- `npm run test --workspace @bandscope/desktop`
- Code Connect/Figma token dependency search returned no package/config/token matches

## Review-Agent Governance
Please compare OpenCode Agent review coverage with other review agents. If another agent identifies a material issue that OpenCode misses, the follow-up fix belongs in `ContextualWisdomLab/.github` central OpenCode workflow/normalization rather than being bypassed here.