### PR TITLE
Document Figma overflow overlap hardening

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -32,6 +32,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Figma page `33 Figma-Only Readiness Audit` also contains the `2026-07-01 placeholder section pass - PASS` evidence row.
 - Page `32 Screen Blueprints` was hardened after the first visual pass: its mobile and desktop blocks now show concrete UI anatomy for header/role controls, source controls, status/progress, metric cards, navigation, console details, section roadmap, groove map, and export actions.
 - The stricter page 32 audit found `0` label-only/empty blueprint sections and `0` text clipping candidates after those additions.
+- A second-pass 2026-07-01 Figma audit found `10` overflow candidates and `2` sibling-overlap candidates across pages 28-33. Page `29 UI Repair Playbook`, page `31 Component Contract Catalog`, and page `32 Screen Blueprints` were repaired in Figma; the final audit reports `0` overflow candidates and `0` sibling-overlap candidates.
 - `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
 - If a Figma metadata overview appears to show pages 28-33 as empty, inspect the page root node directly before treating it as a defect. The verified root IDs are `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, and `50:133`.
 - If a blueprint block is only a large labeled box, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The 2026-07-01 audit found the code was implemented, so Figma page 32 was corrected instead of changing app code.
@@ -64,8 +65,9 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
 - If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
 - If a Figma screen blueprint contains placeholder-only or label-only sections, compare against the runtime code first. Implement code only when the surface is missing; otherwise fill the Figma blueprint with concrete UI anatomy.
+- If a Figma card or blueprint detail visibly overflows its parent, overlaps a sibling, or depends on unclipped spillover to be readable, treat it as a Figma handoff defect unless the corresponding runtime surface is missing.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
-- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, and `2026-07-01 placeholder section pass` rows on page 33 current whenever those tools, standards, or visual audit results change.
+- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, `2026-07-01 placeholder section pass`, and `2026-07-01 overflow/overlap repair pass` rows on page 33 current whenever those tools, standards, or visual audit results change.
 
 ## Current UI Defects Covered
 

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -20,11 +20,12 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 6. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
 7. Inspect the actual code component before editing.
 8. If a Figma blueprint block is placeholder-only, verify whether the matching runtime surface exists before coding. Fill Figma when the code already exists; implement code only when the surface is genuinely missing.
-9. Implement with existing components first.
-10. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
-11. Verify with typecheck and the narrowest useful test command.
-12. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
-13. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
+9. If a Figma card, contract row, or blueprint detail overflows its parent or overlaps a sibling, repair Figma first unless the runtime surface is genuinely missing.
+10. Implement with existing components first.
+11. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
+12. Verify with typecheck and the narrowest useful test command.
+13. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
+14. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
 
 ## What Figma Can Provide
 
@@ -36,6 +37,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Tool access limits on `33 Figma-Only Readiness Audit`, including the 2026-07-01 `Ponytail` and `Superpowers` recheck note.
 - Visual audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have visible root frames and no remaining manual-height text clipping candidates.
 - Placeholder-section audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 32 has no remaining label-only blueprint sections.
+- Overflow/overlap repair evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have no remaining parent overflow candidates or sibling-overlap candidates after page 29, page 31, and page 32 geometry repairs.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -64,6 +66,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
 - A page-level Figma metadata overview appears empty but the page root node has not been inspected directly.
 - A Figma screen blueprint has a large placeholder-only or label-only section and the matching runtime surface has not been checked.
+- A Figma row, card, or blueprint detail only reads correctly because text or nested content spills outside its parent or overlaps a neighboring element.
 - A generated Figma layout would require duplicating an existing component.
 - The implementation would add a Figma token, access token, publish step, or platform-plan requirement.
 - Visual parity conflicts with accessibility, keyboard behavior, localization, or responsive constraints.


### PR DESCRIPTION
## Summary
- repaired second-pass Figma visual handoff defects: page 29 recipe card overflow, page 31 Source Control Stack contract row overlap, and page 32 mobile/desktop blueprint overflow/overlap candidates
- added the `2026-07-01 overflow/overlap repair pass - PASS` evidence row to Figma page 33
- updated repo mirror docs so frontend engineers and publishers treat Figma spillover/overlap as a handoff defect unless runtime code is genuinely missing

## Figma Evidence
- File: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
- Page 29 `UI Repair Playbook`: recipe cards resized/reflowed after 6 overflow candidates
- Page 31 `Component Contract Catalog`: Source Control Stack Props/TSX/QA spacing repaired
- Page 32 `Screen Blueprints`: mobile header/status/roadmap containment repaired; desktop medium confidence badge moved out of label overlap
- Page 33 `Figma-Only Readiness Audit`: new second-pass PASS row added
- Final Figma structural audit: `overflowCount: 0`, `siblingOverlapCount: 0` across pages 28-33

## Code Decision
No app runtime code changed. The audited runtime surfaces already exist; this pass fixed Figma handoff geometry and documentation mirror defects.

## Verification
- `py -3 scripts/checks/verify_docs.py`
- `git diff --check`
- no Figma Code Connect/token dependency matches via `rg`
- `npm run typecheck --workspace @bandscope/desktop`
- `npm run lint --workspace @bandscope/desktop`
- `npm run build --workspace @bandscope/desktop`
- `npm run test --workspace @bandscope/desktop` (118 tests)

## Review-Agent Governance
OpenCode Agent and other review agents should treat the Figma overflow/overlap evidence as the bounded review surface. If another review agent finds an actionable issue that OpenCode misses, this will be escalated to `ContextualWisdomLab/.github` as a central OpenCode workflow/normalizer defect.