### PR TITLE
Document workspace state matrix handoff

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1184,6 +1184,33 @@ describe("App", () => {
     });
   });
 
+  it("redacts local paths from project load failures", async () => {
+    mockLoadProject.mockRejectedValueOnce(new Error("Could not open C:\\Users\\Seongho\\private-set.band\nstack detail"));
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open project/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load project: Could not open \[local path\]/i)).toBeTruthy();
+    });
+    const alertText = screen.getByRole("alert").textContent ?? "";
+    expect(alertText).not.toMatch(/C:\\Users\\Seongho/i);
+    expect(alertText).not.toMatch(/stack detail/i);
+  });
+
+  it("truncates oversized project load failure details", async () => {
+    const longDetail = "A".repeat(260);
+    mockLoadProject.mockRejectedValueOnce(new Error(longDetail));
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open project/i }));
+
+    const truncatedDetail = `${longDetail.slice(0, 217)}...`;
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(`Failed to load project: ${truncatedDetail}`);
+    });
+  });
+
   it("ignores cancellation when loading a project with string error", async () => {
     mockLoadProject.mockRejectedValueOnce("User cancelled");
     render(<App />);
@@ -1279,6 +1306,32 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to save project: Disk full/i)).toBeTruthy();
     });
+  });
+
+  it("redacts links, local paths, and secret assignments from project save failures", async () => {
+    mockLoadProject.mockResolvedValueOnce(succeededResult().result);
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open project/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Late Night Set/i })).toBeTruthy();
+    });
+
+    mockSaveProject.mockRejectedValueOnce(
+      new Error("Upload failed for https://example.com/report?token=abc access_token=secret123 at /Users/seongho/private.band")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save project/i }));
+
+    let alertText = "";
+    await waitFor(() => {
+      alertText = screen.getByRole("alert").textContent ?? "";
+      expect(alertText).toMatch(/Failed to save project:/i);
+    });
+    expect(alertText).toMatch(/\[link\]/i);
+    expect(alertText).toMatch(/access_token=\[redacted\]/i);
+    expect(alertText).toMatch(/\[local path\]/i);
+    expect(alertText).not.toMatch(/example\.com|secret123|\/Users\/seongho/i);
   });
 
   it("ignores cancellation when saving a project with string error", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -48,6 +48,10 @@ import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 
 const ANALYSIS_POLL_INTERVAL_MS = 250;
+const MAX_ERROR_DETAIL_LENGTH = 220;
+const LOCAL_PATH_PATTERN = /(?:[A-Za-z]:[\\/][^\s"'<>]+|\\\\[^\s"'<>]+|\/(?:Users|home|var|tmp|private|Volumes)\/[^\s"'<>]+)/g;
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'<>]+/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b(token|secret|password|api[_-]?key|access[_-]?token)\s*[:=]\s*[^\s,;]+/gi;
 
 const NAV_ITEMS = [
   { label: "Workspace", icon: Home, active: true },
@@ -82,6 +86,44 @@ function progressMessage(
     case "failed":
       return t("analysisStateFailed");
   }
+}
+
+/** Documented. */
+function rawErrorMessage(error: unknown): string | null {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return null;
+}
+
+/** Documented. */
+function isUserCancellation(error: unknown): boolean {
+  return rawErrorMessage(error)?.trim() === "User cancelled";
+}
+
+/** Documented. */
+function safeErrorDetail(error: unknown, fallback: string): string {
+  const raw = rawErrorMessage(error);
+  if (!raw?.trim()) {
+    return fallback;
+  }
+
+  const firstLine = raw
+    .split(/\r?\n/)[0]
+    .replace(/\s+/g, " ")
+    .trim();
+  const redacted = firstLine
+    .replace(URL_PATTERN, "[link]")
+    .replace(SECRET_ASSIGNMENT_PATTERN, (_match: string, key: string) => `${key}=[redacted]`)
+    .replace(LOCAL_PATH_PATTERN, "[local path]")
+    .trim();
+
+  return redacted.length > MAX_ERROR_DETAIL_LENGTH
+    ? `${redacted.slice(0, MAX_ERROR_DETAIL_LENGTH - 3)}...`
+    : redacted;
 }
 
 /** Documented. */
@@ -212,7 +254,7 @@ export function App() {
     }
     if (nextStatus.state === "failed") {
       setActiveAnalysisBootstrap(null);
-      setJobError(nextStatus.error?.message ?? t("analysisCouldNotStart"));
+      setJobError(safeErrorDetail(nextStatus.error?.message, t("analysisCouldNotStart")));
     }
   }, [activeAnalysisBootstrap, t]);
 
@@ -343,7 +385,7 @@ export function App() {
     }
 
     setSelectedBootstrap(null);
-    setSelectionError(selection.error.message || t("unsupportedLocalAudio"));
+    setSelectionError(safeErrorDetail(selection.error.message, t("unsupportedLocalAudio")));
     setJobStatus(null);
   };
 
@@ -368,7 +410,7 @@ export function App() {
         setSelectedBootstrap(selection.bootstrap);
         setYoutubeUrl("");
       } else {
-        setSelectionError(selection.error.message || t("youtubeImportFailed"));
+        setSelectionError(safeErrorDetail(selection.error.message, t("youtubeImportFailed")));
       }
     } catch {
       setSelectionError(t("youtubeImportFailed"));
@@ -388,10 +430,8 @@ export function App() {
       setActiveAnalysisBootstrap(null);
       setJobStatus(null);
     } catch (e) {
-      if (e instanceof Error && e.message !== "User cancelled") {
-        setJobError(`Failed to load project: ${e.message}`);
-      } else if (typeof e === "string" && e !== "User cancelled") {
-        setJobError(`Failed to load project: ${e}`);
+      if (!isUserCancellation(e)) {
+        setJobError(`Failed to load project: ${safeErrorDetail(e, "The selected project could not be loaded.")}`);
       }
     }
   };
@@ -401,10 +441,8 @@ export function App() {
     try {
       await saveProject(jobResult!);
     } catch (e) {
-      if (e instanceof Error && e.message !== "User cancelled") {
-        setJobError(`Failed to save project: ${e.message}`);
-      } else if (typeof e === "string" && e !== "User cancelled") {
-        setJobError(`Failed to save project: ${e}`);
+      if (!isUserCancellation(e)) {
+        setJobError(`Failed to save project: ${safeErrorDetail(e, "The project could not be saved.")}`);
       }
     }
   };

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -16,7 +16,7 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 ## Working Model
 
 1. Start from the Figma component or screen to understand visual intent.
-2. Read `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit` in the Figma file.
+2. Read `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, `33 Figma-Only Readiness Audit`, and `34 Workspace State Matrix` in the Figma file.
 3. Use [component-contract.md](component-contract.md) as a repo mirror of the Figma-only contract.
 4. Implement with the listed code component and allowed props before adding local markup.
 5. Use documented token classes and component variants first; add one-off classes only for domain-specific visual emphasis.
@@ -36,6 +36,9 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
 - If a Figma metadata overview appears to show pages 28-33 as empty, inspect the page root node directly before treating it as a defect. The verified root IDs are `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, and `50:133`.
 - If a blueprint block is only a large labeled box, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The 2026-07-01 audit found the code was implemented, so Figma page 32 was corrected instead of changing app code.
+- A third-pass 2026-07-01 state audit found the app already implements `EmptyState`, `LoadingState`, and `ErrorState` in [WorkspaceStates.tsx](../../apps/desktop/src/features/workspace/WorkspaceStates.tsx), with routing in [App.tsx](../../apps/desktop/src/App.tsx). Figma was missing a standalone whole-workspace state contract, so page `34 Workspace State Matrix` was added with root node `80:3`.
+- Page `33 Figma-Only Readiness Audit` contains `2026-07-01 workspace state contract pass - PASS` at node `80:130`.
+- The final structural audit across pages `28` through `34` reported `0` empty frames/sections, `0` low-detail placeholder sections, `0` manual-height clipping candidates, and `0` top-level overlap candidates.
 
 ## Frontend Engineer Checklist
 
@@ -43,6 +46,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Treat [component-contract.md](component-contract.md) as a review mirror, not a replacement for the Figma page.
 - Keep `Button`, `Badge`, `Input`, `Tabs`, `Progress`, and `Card` semantics intact instead of recreating them with raw elements.
 - Preserve focus states, disabled states, `aria-invalid`, labels, and keyboard-accessible regions.
+- Use `34 Workspace State Matrix` before changing workspace empty, loading, error, ready, Groove Map, or Source Control Stack state behavior.
 - Keep mobile touch actions at 40px or larger when the design uses the Touch state.
 - Keep source controls above the fold on narrow screens and allow wrapping before clipping.
 - Preserve the contract test in `apps/desktop/src/App.test.tsx` that keeps `Source controls` before `Analysis summary`.
@@ -60,14 +64,14 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 
 ## Figma Maintenance
 
-- Keep the Figma Handoff Notes page linked to Figma-only pages first: `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit`.
+- Keep the Figma Handoff Notes page linked to Figma-only pages first: `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, `33 Figma-Only Readiness Audit`, and `34 Workspace State Matrix`.
 - Keep component descriptions focused on code path, usage, state mapping, and known UI defects.
 - Update Figma variants only after confirming the repo component supports the state or after opening a follow-up implementation task.
 - If a detail needed for implementation is absent from Figma, treat that absence as a design-system defect and update Figma before coding.
 - If a Figma screen blueprint contains placeholder-only or label-only sections, compare against the runtime code first. Implement code only when the surface is missing; otherwise fill the Figma blueprint with concrete UI anatomy.
 - If a Figma card or blueprint detail visibly overflows its parent, overlaps a sibling, or depends on unclipped spillover to be readable, treat it as a Figma handoff defect unless the corresponding runtime surface is missing.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
-- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, `2026-07-01 placeholder section pass`, and `2026-07-01 overflow/overlap repair pass` rows on page 33 current whenever those tools, standards, or visual audit results change.
+- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, `2026-07-01 placeholder section pass`, `2026-07-01 overflow/overlap repair pass`, and `2026-07-01 workspace state contract pass` rows on page 33 current whenever those tools, standards, visual audit results, or runtime state contracts change.
 
 ## Current UI Defects Covered
 
@@ -79,3 +83,4 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - Compact navigation clipping: allow trigger wrapping and avoid fixed-width labels.
 - Heavy nested cards: prefer `Card` once per logical panel, with repeated rows inside.
 - Dense uppercase labels: keep metadata short and use normal body text for explanations.
+- Workspace empty/loading/error handoff gap: page `34 Workspace State Matrix` now maps runtime triggers, visual anatomy, code paths, and role/aria expectations before implementation.

--- a/docs/design-system/component-contract.md
+++ b/docs/design-system/component-contract.md
@@ -34,6 +34,7 @@ The authoritative Figma view is `31 Component Contract Catalog`. This file mirro
 | Groove Map | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-526 | `apps/desktop/src/features/workspace/GrooveMap.tsx` | Use `notes?: TranscriptionNote[]` and `isLoading?: boolean`; preserve scrollable region semantics and note labels. |
 | Source Control Stack | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-655 | `apps/desktop/src/App.tsx` | Feature-local source controls for local audio, YouTube URL import, project actions, and Start Analysis; keep before metrics at 375px. |
 | Export Action Group | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-731 | `apps/desktop/src/features/workspace/Workspace.tsx` | Feature-local export buttons call `handleExportCueSheet`, `handleExportChart`, and `handleExportHandoff`. |
+| Workspace State Matrix | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=80-3 | `apps/desktop/src/features/workspace/WorkspaceStates.tsx`, `apps/desktop/src/App.tsx` | Whole-workspace empty, loading, error, and ready state routing; use before changing `renderWorkspaceState()`. |
 
 ## Prop And State Mapping
 
@@ -72,6 +73,15 @@ The authoritative Figma view is `31 Component Contract Catalog`. This file mirro
 - Tone-specific colors belong on `ProgressIndicator` or scoped child selectors.
 - Provide adjacent live text when progress reflects an active asynchronous job.
 
+### Workspace States
+
+- Figma page `34 Workspace State Matrix` maps `EmptyState`, `LoadingState`, `ErrorState`, ready `Workspace`, `GrooveMap`, and Source Control Stack substates.
+- `App.tsx` must preserve the current routing order: `jobError` -> `ErrorState`, `analysisInFlight || isStarting` -> `LoadingState`, `jobResult` -> `Workspace`, otherwise `EmptyState`.
+- `LoadingState` keeps `role="status"`, `aria-live="polite"`, `aria-atomic="true"`, and `aria-busy="true"`.
+- `ErrorState` keeps `role="alert"`, `aria-live="assertive"`, and visible safe error detail copy.
+- `EmptyState` must remain an actionable state card, not a blank placeholder panel.
+- If a new workspace state is added in code, update Figma page 34 and page 33 audit evidence before merging.
+
 ## Pattern Backlog
 
 These Figma patterns are valid visual guidance but are not yet extracted as standalone code components. Use the existing feature markup and open a follow-up extraction task when reuse appears twice.
@@ -91,4 +101,5 @@ These Figma patterns are valid visual guidance but are not yet extracted as stan
 - A new component variant must update this file, the relevant component tests, and the Figma component notes.
 - A new Figma-only pattern must enter the Pattern Backlog before being reused.
 - Any deliberate visual divergence from Figma should state whether the repo contract or accessibility requirement caused it.
+- Workspace state changes must cite page `34 Workspace State Matrix` or explain why Figma was updated first.
 - Do not add Code Connect, Figma token, or Figma publish requirements to CI.

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -16,16 +16,17 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 2. Read Figma structure and variants through Figma MCP or the node URL.
 3. Read `31 Component Contract Catalog` for the matching source path, current runtime API, TSX example, and QA note.
 4. Read `32 Screen Blueprints` for mobile and desktop placement before changing layout.
-5. Check `33 Figma-Only Readiness Audit` for current visual audit evidence and tool access limits before deciding a Figma page is empty or a plugin-backed review is required.
-6. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
-7. Inspect the actual code component before editing.
-8. If a Figma blueprint block is placeholder-only, verify whether the matching runtime surface exists before coding. Fill Figma when the code already exists; implement code only when the surface is genuinely missing.
-9. If a Figma card, contract row, or blueprint detail overflows its parent or overlaps a sibling, repair Figma first unless the runtime surface is genuinely missing.
-10. Implement with existing components first.
-11. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
-12. Verify with typecheck and the narrowest useful test command.
-13. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
-14. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
+5. Read `34 Workspace State Matrix` before changing workspace empty, loading, error, ready, Groove Map, or Source Control Stack states.
+6. Check `33 Figma-Only Readiness Audit` for current visual audit evidence and tool access limits before deciding a Figma page is empty or a plugin-backed review is required.
+7. Use [component-contract.md](component-contract.md) only as a repo mirror when working in code review.
+8. Inspect the actual code component before editing.
+9. If a Figma blueprint block is placeholder-only, verify whether the matching runtime surface exists before coding. Fill Figma when the code already exists; implement code only when the surface is genuinely missing.
+10. If a Figma card, contract row, or blueprint detail overflows its parent or overlaps a sibling, repair Figma first unless the runtime surface is genuinely missing.
+11. Implement with existing components first.
+12. Add or update tests when behavior, accessibility, reading order, or reusable component APIs change.
+13. Verify with typecheck and the narrowest useful test command.
+14. For visible UI changes, run the app and compare desktop and mobile screenshots against Figma intent.
+15. If implementation needs to diverge from Figma, document whether the code API, accessibility, runtime behavior, or responsive layout caused the divergence.
 
 ## What Figma Can Provide
 
@@ -34,10 +35,12 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Visual measurements, spacing, hierarchy, state examples, and screenshots.
 - Mobile 375x812 and desktop 1440x900 repair targets on `32 Screen Blueprints`.
 - Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
+- Whole-workspace empty, loading, error, ready, Groove Map, and Source Control Stack state contracts on `34 Workspace State Matrix`.
 - Tool access limits on `33 Figma-Only Readiness Audit`, including the 2026-07-01 `Ponytail` and `Superpowers` recheck note.
 - Visual audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have visible root frames and no remaining manual-height text clipping candidates.
 - Placeholder-section audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 32 has no remaining label-only blueprint sections.
 - Overflow/overlap repair evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have no remaining parent overflow candidates or sibling-overlap candidates after page 29, page 31, and page 32 geometry repairs.
+- Workspace state repair evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 34 covers the implemented `WorkspaceStates.tsx` state contract.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -54,6 +57,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Translate Figma `Input` states through native `type`, `disabled`, and `aria-invalid`.
 - Translate Figma `Tabs Trigger` through `Tabs`, `TabsList`, and `TabsTrigger`.
 - Translate confidence UI through `ConfidenceBadge`, not local color classes.
+- Translate `34 Workspace State Matrix` through `EmptyState`, `LoadingState`, `ErrorState`, `Workspace`, `GrooveMap`, and the feature-local Source Control Stack. Do not replace these states with blank panels.
 - Translate Figma pattern components in the backlog as feature-local markup until reuse justifies extraction.
 - Keep generated Figma asset URLs out of production code unless the asset has been intentionally added to the repo.
 
@@ -63,6 +67,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A Figma variant has no supported code prop or class strategy.
 - A Figma contract names a prop that does not exist in the current runtime component.
 - A required implementation detail exists only in repo docs and not in Figma.
+- A workspace empty, loading, error, ready, Groove Map, or Source Control Stack state is not represented on `34 Workspace State Matrix`, page `25 Groove Map`, page `26 Source Control Stack`, or page `31 Component Contract Catalog`.
 - A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
 - A page-level Figma metadata overview appears empty but the page root node has not been inspected directly.
 - A Figma screen blueprint has a large placeholder-only or label-only section and the matching runtime surface has not been checked.


### PR DESCRIPTION
## Summary
- Added Figma page `34 Workspace State Matrix` with root `80:3` for whole-workspace empty/loading/error/ready state handoff.
- Added page `33 Figma-Only Readiness Audit` evidence row `80:130` for the 2026-07-01 workspace state contract pass.
- Mirrored the new Figma-only state contract in `docs/design-system` so Frontend Engineers and Publishers know when to use page 34 before code changes.
- Addressed Copilot review by sanitizing user-visible workspace/source-control error details: local paths, links, and secret assignments are redacted, multiline details are collapsed to the first line, and oversized messages are truncated.

## Code decision
- The whole-workspace state surface already existed: `WorkspaceStates.tsx` implements `EmptyState`, `LoadingState`, and `ErrorState`, and `App.tsx renderWorkspaceState()` already routes those states.
- The original Figma defect was missing Figma-local state-contract detail, repaired in Figma + docs.
- The review pass found a real code/documentation mismatch around safe error details, now fixed in `App.tsx` with regression coverage in `App.test.tsx`.

## Figma verification
- Final structural audit across pages 28-34: `empty=0`, `low=0`, `clipping=0`, `topLevelOverlaps=0`.
- Screenshot-render checked page 34 after removing duplicate text and childless-frame false positives.

## Verification
- `py -3 scripts/checks/verify_docs.py`
- `git diff --check`
- `npm --workspace @bandscope/desktop run lint`
- `npm --workspace @bandscope/desktop run typecheck`
- `npm --workspace @bandscope/desktop run test` (121 tests, 100% statements/branches/functions/lines)
- `npm --workspace @bandscope/desktop run build`