### PR TITLE
Document fourth-pass Figma handoff restore

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -497,6 +497,12 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getAllByRole("status").some((status) => /queued for analysis/i.test(status.textContent ?? ""))).toBe(true);
     });
+    await waitFor(() => {
+      expect(mockSubscribeToAnalysisJobUpdates).toHaveBeenCalledWith(
+        "job-unlabeled-status",
+        expect.any(Function)
+      );
+    });
 
     const completed = succeededResult();
     delete (completed as { progressLabel?: string }).progressLabel;

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -11,7 +11,7 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 - Frontend work must resolve conflicts by checking both Figma-local contract pages and production code.
 - Figma component names and variant names should mirror the repo contract so visual review remains straightforward.
 - Do not introduce required Figma platform features into build, test, release, or CI flows.
-- `Ponytail`, `Superpowers`, and `Product Design` are recorded on Figma page `33 Figma-Only Readiness Audit` as review perspectives for this handoff. The 2026-07-01 fourth pass used the available local skill instructions and kept them as process/design lenses, not Figma platform dependencies.
+- `Ponytail`, `Superpowers`, and `Product Design` are recorded on Figma page `33 Figma-Only Readiness Audit` as review perspectives for this handoff. The 2026-07-01 fourth pass applies those perspectives through the Figma readiness-audit page and this repo mirror: complexity trimming, review/verification discipline, and visual/state handoff quality. They are process/design lenses, not Figma platform dependencies.
 
 ## Working Model
 
@@ -29,6 +29,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - The 2026-07-01 fourth pass found that Figma pages `28 Implementation Contract` through `34 Workspace State Matrix` could appear empty or stale unless each page was loaded before inspection. Some pages also had duplicate historical roots. That mismatch was treated as a design-system defect.
 - Pages `28` through `34` were loaded with `figma.setCurrentPageAsync(page)`, cleaned to one visible root each, and rebuilt in Figma with text-bearing nodes, code paths, state maps, QA rules, and concrete mobile/desktop screen anatomy.
 - Current verified Figma root IDs are `99:2` (`28 Implementation Contract`), `99:82` (`29 UI Repair Playbook`), `99:171` (`30 Publisher + QA Matrix`), `99:253` (`31 Component Contract Catalog`), `99:415` (`32 Screen Blueprints`), `99:714` (`33 Figma-Only Readiness Audit`), and `99:560` (`34 Workspace State Matrix`).
+- Use colon-form IDs such as `99:560` in Figma Plugin API calls. Use hyphen-form IDs such as `node-id=99-560` in Figma URLs.
 - The post-rebuild structural audit reported `0` empty pages, `0` duplicate roots, `0` empty roots, `0` low-detail placeholder sections, `0` manual-height clipping candidates, `0` parent-overflow candidates, and `0` top-level overlap candidates across pages `28` through `34`.
 - `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
 - If a Figma page or blueprint section is empty, label-only, or structurally detached from its visible text, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The fourth pass found the relevant runtime surfaces already implemented, so Figma was corrected instead of adding code.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -11,7 +11,7 @@ Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
 - Frontend work must resolve conflicts by checking both Figma-local contract pages and production code.
 - Figma component names and variant names should mirror the repo contract so visual review remains straightforward.
 - Do not introduce required Figma platform features into build, test, release, or CI flows.
-- `Ponytail` and `Superpowers` are recorded on Figma page `33 Figma-Only Readiness Audit` as unavailable callable tools for this handoff. The explicit plugin links were rechecked on 2026-07-01 and still exposed no callable tools or install candidates, so treat them as named review perspectives only unless a future session exposes actual tools or project standards for them.
+- `Ponytail`, `Superpowers`, and `Product Design` are recorded on Figma page `33 Figma-Only Readiness Audit` as review perspectives for this handoff. The 2026-07-01 fourth pass used the available local skill instructions and kept them as process/design lenses, not Figma platform dependencies.
 
 ## Working Model
 
@@ -26,19 +26,13 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 
 ## Visual Audit Snapshot
 
-- Figma page `33 Figma-Only Readiness Audit` contains the `2026-07-01 visual pass - PASS` evidence row.
-- Pages `28 Implementation Contract`, `29 UI Repair Playbook`, `30 Publisher + QA Matrix`, `31 Component Contract Catalog`, `32 Screen Blueprints`, and `33 Figma-Only Readiness Audit` each contain one visible root frame.
-- The 2026-07-01 Figma audit found no empty root, hidden root, top-level overlap candidate, or remaining manual-height text clipping candidate on pages 28-33 after the intro and gap text was changed to auto-height.
-- Figma page `33 Figma-Only Readiness Audit` also contains the `2026-07-01 placeholder section pass - PASS` evidence row.
-- Page `32 Screen Blueprints` was hardened after the first visual pass: its mobile and desktop blocks now show concrete UI anatomy for header/role controls, source controls, status/progress, metric cards, navigation, console details, section roadmap, groove map, and export actions.
-- The stricter page 32 audit found `0` label-only/empty blueprint sections and `0` text clipping candidates after those additions.
-- A second-pass 2026-07-01 Figma audit found `10` overflow candidates and `2` sibling-overlap candidates across pages 28-33. Page `29 UI Repair Playbook`, page `31 Component Contract Catalog`, and page `32 Screen Blueprints` were repaired in Figma; the final audit reports `0` overflow candidates and `0` sibling-overlap candidates.
+- The 2026-07-01 fourth pass found that Figma pages `28 Implementation Contract` through `34 Workspace State Matrix` could appear empty or stale unless each page was loaded before inspection. Some pages also had duplicate historical roots. That mismatch was treated as a design-system defect.
+- Pages `28` through `34` were loaded with `figma.setCurrentPageAsync(page)`, cleaned to one visible root each, and rebuilt in Figma with text-bearing nodes, code paths, state maps, QA rules, and concrete mobile/desktop screen anatomy.
+- Current verified Figma root IDs are `99:2` (`28 Implementation Contract`), `99:82` (`29 UI Repair Playbook`), `99:171` (`30 Publisher + QA Matrix`), `99:253` (`31 Component Contract Catalog`), `99:415` (`32 Screen Blueprints`), `99:714` (`33 Figma-Only Readiness Audit`), and `99:560` (`34 Workspace State Matrix`).
+- The post-rebuild structural audit reported `0` empty pages, `0` duplicate roots, `0` empty roots, `0` low-detail placeholder sections, `0` manual-height clipping candidates, `0` parent-overflow candidates, and `0` top-level overlap candidates across pages `28` through `34`.
 - `32 Screen Blueprints` remains the visual target for source-first mobile and desktop repair work. The current app implements that source-first order in [App.tsx](../../apps/desktop/src/App.tsx), and the regression is covered by [App.test.tsx](../../apps/desktop/src/App.test.tsx).
-- If a Figma metadata overview appears to show pages 28-33 as empty, inspect the page root node directly before treating it as a defect. The verified root IDs are `50:2`, `50:20`, `50:59`, `51:2`, `50:86`, and `50:133`.
-- If a blueprint block is only a large labeled box, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The 2026-07-01 audit found the code was implemented, so Figma page 32 was corrected instead of changing app code.
-- A third-pass 2026-07-01 state audit found the app already implements `EmptyState`, `LoadingState`, and `ErrorState` in [WorkspaceStates.tsx](../../apps/desktop/src/features/workspace/WorkspaceStates.tsx), with routing in [App.tsx](../../apps/desktop/src/App.tsx). Figma was missing a standalone whole-workspace state contract, so page `34 Workspace State Matrix` was added with root node `80:3`.
-- Page `33 Figma-Only Readiness Audit` contains `2026-07-01 workspace state contract pass - PASS` at node `80:130`.
-- The final structural audit across pages `28` through `34` reported `0` empty frames/sections, `0` low-detail placeholder sections, `0` manual-height clipping candidates, and `0` top-level overlap candidates.
+- If a Figma page or blueprint section is empty, label-only, or structurally detached from its visible text, treat that as a Figma handoff defect unless the corresponding runtime surface is genuinely unimplemented. The fourth pass found the relevant runtime surfaces already implemented, so Figma was corrected instead of adding code.
+- A runtime state audit found the app already implements `EmptyState`, `LoadingState`, and `ErrorState` in [WorkspaceStates.tsx](../../apps/desktop/src/features/workspace/WorkspaceStates.tsx), with routing in [App.tsx](../../apps/desktop/src/App.tsx). Page `34 Workspace State Matrix` now mirrors that contract with visible text nodes at root `99:560`.
 
 ## Frontend Engineer Checklist
 
@@ -71,7 +65,7 @@ Codex and other implementation agents must follow [figma-to-code-workflow.md](fi
 - If a Figma screen blueprint contains placeholder-only or label-only sections, compare against the runtime code first. Implement code only when the surface is missing; otherwise fill the Figma blueprint with concrete UI anatomy.
 - If a Figma card or blueprint detail visibly overflows its parent, overlaps a sibling, or depends on unclipped spillover to be readable, treat it as a Figma handoff defect unless the corresponding runtime surface is missing.
 - If Code Connect becomes available later, treat it as an optional publishing layer over this contract, not as the source of truth.
-- Keep the `Ponytail and Superpowers access note`, `2026-07-01 visual pass`, `2026-07-01 placeholder section pass`, `2026-07-01 overflow/overlap repair pass`, and `2026-07-01 workspace state contract pass` rows on page 33 current whenever those tools, standards, visual audit results, or runtime state contracts change.
+- Keep the `Ponytail`, `Superpowers`, `Product Design`, fourth-pass empty-page restore, hierarchy audit, structural audit, and workspace state contract rows on page 33 current whenever those tools, standards, visual audit results, or runtime state contracts change.
 
 ## Current UI Defects Covered
 

--- a/docs/design-system/component-contract.md
+++ b/docs/design-system/component-contract.md
@@ -34,7 +34,7 @@ The authoritative Figma view is `31 Component Contract Catalog`. This file mirro
 | Groove Map | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-526 | `apps/desktop/src/features/workspace/GrooveMap.tsx` | Use `notes?: TranscriptionNote[]` and `isLoading?: boolean`; preserve scrollable region semantics and note labels. |
 | Source Control Stack | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-655 | `apps/desktop/src/App.tsx` | Feature-local source controls for local audio, YouTube URL import, project actions, and Start Analysis; keep before metrics at 375px. |
 | Export Action Group | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=19-731 | `apps/desktop/src/features/workspace/Workspace.tsx` | Feature-local export buttons call `handleExportCueSheet`, `handleExportChart`, and `handleExportHandoff`. |
-| Workspace State Matrix | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=80-3 | `apps/desktop/src/features/workspace/WorkspaceStates.tsx`, `apps/desktop/src/App.tsx` | Whole-workspace empty, loading, error, and ready state routing; use before changing `renderWorkspaceState()`. |
+| Workspace State Matrix | https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk/Bandscope-Design-System-v1?node-id=99-560 | `apps/desktop/src/features/workspace/WorkspaceStates.tsx`, `apps/desktop/src/App.tsx` | Whole-workspace empty, loading, error, and ready state routing; use before changing `renderWorkspaceState()`. |
 
 ## Prop And State Mapping
 

--- a/docs/design-system/figma-to-code-workflow.md
+++ b/docs/design-system/figma-to-code-workflow.md
@@ -36,11 +36,10 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - Mobile 375x812 and desktop 1440x900 repair targets on `32 Screen Blueprints`.
 - Figma-only readiness evidence on `33 Figma-Only Readiness Audit`.
 - Whole-workspace empty, loading, error, ready, Groove Map, and Source Control Stack state contracts on `34 Workspace State Matrix`.
-- Tool access limits on `33 Figma-Only Readiness Audit`, including the 2026-07-01 `Ponytail` and `Superpowers` recheck note.
-- Visual audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have visible root frames and no remaining manual-height text clipping candidates.
-- Placeholder-section audit evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 32 has no remaining label-only blueprint sections.
-- Overflow/overlap repair evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms pages 28-33 have no remaining parent overflow candidates or sibling-overlap candidates after page 29, page 31, and page 32 geometry repairs.
-- Workspace state repair evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 pass that confirms page 34 covers the implemented `WorkspaceStates.tsx` state contract.
+- Review perspective notes on `33 Figma-Only Readiness Audit`, including how `Ponytail`, `Superpowers`, and `Product Design` were applied without adding Figma platform dependencies.
+- Fourth-pass restore evidence on `33 Figma-Only Readiness Audit`, including the 2026-07-01 finding that pages 28-34 could appear empty or stale unless each page was loaded before inspection.
+- Structural audit evidence on `33 Figma-Only Readiness Audit`, including the post-restore pass that loads each page with `figma.setCurrentPageAsync(page)` and confirms pages 28-34 have one visible text-bearing root frame with no empty, duplicate-root, low-detail, parent-overflow, manual-height clipping, or top-level overlap candidates.
+- Workspace state repair evidence on `33 Figma-Only Readiness Audit`, including the rebuilt page 34 root `99:560` that covers the implemented `WorkspaceStates.tsx` state contract.
 - Domain patterns such as Source Control Stack, Groove Map, Section Roadmap Card, and Export Action Group.
 - UI-defect guidance for clipping, touch targets, source-control priority, and panel density.
 
@@ -69,7 +68,7 @@ Codex must not paste generated Figma code directly into the app. Generated Figma
 - A required implementation detail exists only in repo docs and not in Figma.
 - A workspace empty, loading, error, ready, Groove Map, or Source Control Stack state is not represented on `34 Workspace State Matrix`, page `25 Groove Map`, page `26 Source Control Stack`, or page `31 Component Contract Catalog`.
 - A named review perspective such as `Ponytail` or `Superpowers` is treated as a tool-backed requirement without an actual available tool or documented project standard.
-- A page-level Figma metadata overview appears empty but the page root node has not been inspected directly.
+- A page-level Figma metadata overview or direct Plugin API page inspection appears empty before the page has been loaded with `figma.setCurrentPageAsync(page)`, or this repo mirror claims populated Figma content that is not present in the loaded Figma page.
 - A Figma screen blueprint has a large placeholder-only or label-only section and the matching runtime surface has not been checked.
 - A Figma row, card, or blueprint detail only reads correctly because text or nested content spills outside its parent or overlaps a neighboring element.
 - A generated Figma layout would require duplicating an existing component.


### PR DESCRIPTION
## Summary
- Restored Figma pages 28-34 by loading each page, removing duplicate/stale roots, and rebuilding one text-bearing root per page.
- Updated the design-system repo mirror with the final Figma root IDs and the loaded-page audit method.
- Confirmed no new runtime UI code was needed because App.tsx, WorkspaceStates.tsx, Workspace.tsx, SectionRoadmap.tsx, and GrooveMap.tsx already implement the relevant surfaces.
- Stabilized the progress-label subscription test after release-preflight exposed a CI timing race.

## Figma Evidence
- Figma file: https://www.figma.com/design/zthWmqfNKUgJBECvv002Qk
- Current roots: 28=`99:2`, 29=`99:82`, 30=`99:171`, 31=`99:253`, 32=`99:415`, 33=`99:714`, 34=`99:560`.
- Loaded-page structural audit: empty pages=0, duplicate roots=0, empty roots=0, low-detail sections=0, manual-height clipping=0, parent overflow=0, top-level overlaps=0.
- Visual screenshot checks were performed for page 32 and page 34; page 32 overflow was fixed after screenshot review.

## Test Plan
- [x] `py -3 scripts\checks\verify_docs.py`
- [x] `git diff --check`
- [x] `npx vitest run src/App.test.tsx -t "uses translated progress labels"`
- [x] `npm run test --workspace @bandscope/desktop`

Note: `npm run check:docs` delegates to `python3`; on this Windows host the `python3` shim exits with only `Python`, so the documentation verifier was run directly with `py -3`.