### PR TITLE
🎨 Palette: [UX improvement] 스크린 리더 접근성 개선

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -647,6 +647,7 @@ export function App() {
                   </Button>
                 ) : (
                   <span tabIndex={0} role="button" aria-disabled="true" title="Analyze a song to enable saving" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <span className="sr-only">Analyze a song to enable saving</span>
                     <Button
                       disabled
                       variant="outline"

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -312,12 +312,15 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
                 <p className="mt-1 text-sm font-semibold text-slate-100">{activeRoleDetails?.name ?? activeRole}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <span className="sr-only">Coming soon</span>
                     <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Play stem</Button>
                   </span>
                   <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <span className="sr-only">Coming soon</span>
                     <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Loop section</Button>
                   </span>
                   <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                    <span className="sr-only">Coming soon</span>
                     <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Solo / mute others</Button>
                   </span>
                   {canTranscribeBass ? (
@@ -331,6 +334,7 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
                     </Button>
                   ) : (
                     <span tabIndex={0} role="button" aria-disabled="true" title={`${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`} className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
+                      <span className="sr-only">{`${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`}</span>
                       <Button
                         type="button"
                         disabled


### PR DESCRIPTION
💡 What: 비활성화된 버튼의 툴팁 래퍼(`span`)에 `sr-only` 클래스를 가진 숨겨진 텍스트를 추가하여 스크린 리더가 비활성화된 이유를 읽을 수 있도록 개선했습니다.
🎯 Why: 기존에는 비활성화된 버튼에 시각적인 툴팁(`title` 속성)만 제공되었고, 스크린 리더는 이 텍스트를 제대로 읽어주지 못해 키보드 사용자는 버튼이 왜 비활성화되어 있는지 알기 어려웠습니다.
📸 Before/After: 시각적 변화 없음 (스크린 리더에서만 차이 발생)
♿ Accessibility: 비활성화된 주요 기능(저장, 재생, 반복, 솔로 등)에 대한 이유를 스크린 리더 사용자에게도 명확하게 전달합니다.

---
*PR created automatically by Jules for task [597475979416023840](https://jules.google.com/task/597475979416023840) started by @seonghobae*