### PR TITLE
🎨 Palette: 비활성화 버튼 접근성 개선

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-01 - Testing components with focusable disabled button wrappers
 **Learning:** When native disabled buttons are wrapped in a focusable `span` to provide accessible tooltips, tests that previously found and clicked the `button` (by temporarily removing the `disabled` attribute) may fail or become overly complex. It is cleaner and more accurate to query the wrapper element (e.g. via its `title`) and fire events on it, reflecting the actual accessible DOM structure.
 **Action:** When testing UI components that wrap disabled buttons in a focusable span for accessibility (e.g., using a tooltip/title), use `screen.getByTitle(...)` to query the wrapper element for interactions like `fireEvent.click` rather than `screen.getByRole('button')`.
+
+## 2024-07-07 - Accessible disabled buttons
+**Learning:** Wrapped disabled buttons in a `span role="button"` with `aria-hidden="true"` breaks native accessibility.
+**Action:** Use native `<Button>` with `aria-disabled="true"`, block clicks via `onClick={(e) => e.preventDefault()}`, and apply visually disabled styling.

--- a/apps/desktop/src/features/workspace/Workspace.test.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { createDemoRehearsalSong, type ProjectBootstrapSummary, type RehearsalSong } from "@bandscope/shared-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Workspace } from "./Workspace";
@@ -133,6 +133,19 @@ describe("Workspace", () => {
 
     expect(screen.getByText("vi pedal anchor")).toBeTruthy();
     expect(screen.getAllByText("Stay on roots if the chorus entrance gets muddy.").length).toBeGreaterThan(0);
+  });
+
+  it("prevents default click events on aria-disabled coming soon buttons", () => {
+    const song = createDemoRehearsalSong();
+    render(<Workspace song={song} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Bass Guitar" }));
+
+    const playStemButton = screen.getByRole("button", { name: "Play stem" });
+    const event = createEvent.click(playStemButton);
+    fireEvent(playStemButton, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(playStemButton.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("exports a metadata-only handoff artifact from the workspace", async () => {

--- a/apps/desktop/src/features/workspace/Workspace.tsx
+++ b/apps/desktop/src/features/workspace/Workspace.tsx
@@ -311,15 +311,9 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
                 <p className="text-xs font-black uppercase tracking-[0.24em] text-emerald-200">Stem Player</p>
                 <p className="mt-1 text-sm font-semibold text-slate-100">{activeRoleDetails?.name ?? activeRole}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Play stem</Button>
-                  </span>
-                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Loop section</Button>
-                  </span>
-                  <span tabIndex={0} role="button" aria-disabled="true" title="Coming soon" className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                    <Button type="button" disabled variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400">Solo / mute others</Button>
-                  </span>
+                  <Button type="button" aria-disabled="true" title="Coming soon" onClick={(e) => e.preventDefault()} variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:border-white/10 aria-disabled:bg-white/5">Play stem</Button>
+                  <Button type="button" aria-disabled="true" title="Coming soon" onClick={(e) => e.preventDefault()} variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:border-white/10 aria-disabled:bg-white/5">Loop section</Button>
+                  <Button type="button" aria-disabled="true" title="Coming soon" onClick={(e) => e.preventDefault()} variant="outline" className="min-h-11 border-white/10 bg-white/5 text-slate-400 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:border-white/10 aria-disabled:bg-white/5">Solo / mute others</Button>
                   {canTranscribeBass ? (
                     <Button
                       type="button"
@@ -330,16 +324,16 @@ export function Workspace({ song, sourceBootstrap = null, onSongUpdate }: Worksp
                       Transcribe Bass
                     </Button>
                   ) : (
-                    <span tabIndex={0} role="button" aria-disabled="true" title={`${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`} className="inline-block cursor-not-allowed rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300">
-                      <Button
+                    <Button
                         type="button"
-                        disabled
+                        aria-disabled="true"
+                        title={`${activeRoleDetails?.name ?? "This role"} transcription is coming soon. Bass is ready first.`}
+                        onClick={(e) => e.preventDefault()}
                         variant="outline"
-                        className="min-h-11 border-emerald-300/20 bg-emerald-300/10 font-semibold text-emerald-100 disabled:border-white/10 disabled:bg-white/5 disabled:text-slate-500"
+                        className="min-h-11 border-emerald-300/20 bg-emerald-300/10 font-semibold text-emerald-100 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:border-white/10 aria-disabled:bg-white/5 aria-disabled:text-slate-500"
                       >
                         Transcribe Bass
                       </Button>
-                    </span>
                   )}
                 </div>
                 <div className="mt-4 grid gap-3 lg:grid-cols-2">


### PR DESCRIPTION
💡 **What**: `Workspace.tsx` 내에서 "Coming soon" 기능들 (예: Play stem, Transcribe Bass 등)의 비활성화 버튼을 감싸고 있던 `<span role="button">`을 제거하고, 네이티브 `<Button>` 컴포넌트 자체에 `aria-disabled="true"`와 `onClick` 핸들러(`preventDefault`)를 사용하여 상태를 제어하도록 수정했습니다.
🎯 **Why**: 브라우저의 기본 `disabled` 속성을 사용할 경우 버튼이 포커스를 받지 못해 키보드 탐색 시 툴팁을 읽어줄 수 없습니다. 이를 우회하기 위해 `span`으로 감쌀 경우 잘못된 DOM 구조(인터랙티브 요소 중첩)와 스크린 리더의 오동작을 유발합니다. 이번 개선으로 키보드 접근성과 의미론적 마크업을 모두 만족시킬 수 있습니다.
♿ **Accessibility**: 스크린 리더 사용자가 탭(Tab) 키로 버튼에 포커스를 이동했을 때 비활성화 상태와 툴팁 내용을 명확하게 인지할 수 있게 되었으며, 잘못된 ARIA 중첩 문제를 해결했습니다. 테스트 코드 역시 추가되어 동작을 보장합니다.

---
*PR created automatically by Jules for task [10739948947501688252](https://jules.google.com/task/10739948947501688252) started by @seonghobae*