### PR TITLE
🛡️ Sentinel: [MEDIUM] 백엔드 YouTube URL 최대 길이 제한 추가

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,9 @@
 **Vulnerability:** Any project identifier that can reach a filesystem path join must be treated as untrusted, even when it is generated internally or passed through IPC lookup flows.
 **Learning:** Reject only dangerous path segments (`.` and `..`) and path separators (`/` and `\`) so the guard blocks traversal without rejecting ordinary identifiers such as `my..id`.
 **Prevention:** Keep project ID validation centralized before `base_root.join(project_id)`, and cover forward-slash, backslash, parent-component, and benign interior-dot cases in unit tests.
+
+## 2025-02-09 - Ensure Maximum URL Length Limit on Backend
+
+**Vulnerability:** The Rust backend (`apps/desktop/src-tauri/src/main.rs`) did not enforce a maximum URL length limit when processing YouTube URLs via `import_youtube_url`. While the frontend enforced `MAX_YOUTUBE_URL_LENGTH = 2000` via the input element, this could be bypassed by an attacker sending requests directly to the Tauri backend API, potentially causing a Denial of Service (DoS) due to unbounded URL parsing and regex matching.
+**Learning:** Input validation must occur at the entry point of untrusted data on the backend, even if it is also validated on the frontend. Relying solely on frontend validation for constraints like string length can expose the backend to resource exhaustion vulnerabilities.
+**Prevention:** Always enforce constraints like maximum length, format validation, and sanitization at the earliest possible point on the backend, typically at the API boundary, regardless of frontend safeguards.

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1107,7 +1107,13 @@ async fn import_youtube_url(
     Err("YouTube import failed with an unknown error.".to_string())
 }
 
+const MAX_YOUTUBE_URL_LENGTH: usize = 2000;
+
 fn is_supported_youtube_url(url: &str) -> bool {
+    if url.len() > MAX_YOUTUBE_URL_LENGTH {
+        return false;
+    }
+
     let parsed_url = match url::Url::parse(url) {
         Ok(u) => u,
         Err(_) => return false,
@@ -1520,6 +1526,9 @@ mod tests {
         ));
         assert!(!is_supported_youtube_url("https://youtu.be/abc123"));
         assert!(!is_supported_youtube_url("https://youtu.be/abc123DEF4!"));
+
+        let long_url = format!("https://youtube.com/watch?v={}", "a".repeat(2000));
+        assert!(!is_supported_youtube_url(&long_url));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Rust 백엔드의 `import_youtube_url`에서 YouTube URL 처리 시 최대 길이 제한을 강제하지 않았습니다. 프론트엔드에서는 2000자로 제한했으나, 백엔드 API에 직접적으로 긴 문자열을 전송할 경우 정규표현식 매칭 및 URL 파싱 과정에서 리소스 고갈로 인한 서비스 거부(DoS) 취약점이 발생할 가능성이 있었습니다.
🎯 Impact: 악의적인 공격자가 과도하게 긴 길이의 URL을 전송함으로써 백엔드 서버의 자원(CPU, 메모리)을 과도하게 소모시킬 수 있습니다.
🔧 Fix: `is_supported_youtube_url` 함수 내부에 2000자의 최대 길이 제한을 추가하여 파서로 넘기기 전에 선제적으로 차단하도록 수정했습니다. 또한, 이 제약조건을 보장하는 단위 테스트를 작성했습니다. `sentinel.md` 저널에 이와 관련된 보안 학습을 성공적으로 기록했습니다.
✅ Verification: `apps/desktop/src-tauri` 내에서 `cargo test`를 실행하여 2000자를 초과하는 URL이 성공적으로 거부되는지 확인했습니다. `quickcheck.sh` 스크립트를 통해 전체 테스트를 완료했습니다.

---
*PR created automatically by Jules for task [18246548664713582701](https://jules.google.com/task/18246548664713582701) started by @seonghobae*